### PR TITLE
janus/tmu: add TMU ring interconnect implementation and spec

### DIFF
--- a/janus/docs/TMU_SPEC.md
+++ b/janus/docs/TMU_SPEC.md
@@ -1,0 +1,781 @@
+# Janus TMU (Tile Management Unit) 微架构规格书
+
+> 版本: 1.0
+> 日期: 2026-02-10
+> 实现代码: `janus/pyc/janus/tmu/janus_tmu_pyc.py`
+
+---
+
+## 1. 概述
+
+### 1.1 TMU 在 Janus 中的定位
+
+Janus 是一个 AI 执行单元，由以下五个核心模块组成：
+
+| 模块 | 全称 | 功能 |
+|------|------|------|
+| **BCC** | Block Control Core | 标量控制核，负责指令调度与流程控制 |
+| **TMU** | Tile Management Unit | Tile 寄存器文件管理单元，通过 Ring 互联提供高带宽数据访问 |
+| **VectorCore** | 向量执行核 | 执行向量运算（load/store 通过 TMU 访问 TileReg） |
+| **Cube** | 矩阵乘计算单元 | 基于 Systolic Array 的矩阵乘法引擎 |
+| **TMA** | Tile Memory Access | 负责 TileReg 与外部 DDR 之间的数据搬运 |
+
+TMU 是 Janus 的**片上数据枢纽**，管理一块名为 **TileReg** 的可配置 SRAM 缓冲区（默认 1MB），通过 **8 站点双向 Ring 互联网络**为各个计算核提供高带宽、低延迟的数据读写服务。
+
+### 1.2 设计目标
+
+- **峰值带宽**: 256B x 8 / cycle = 2048B/cycle
+- **低延迟**: 本地访问（node 访问自身 pipe）仅需 4 cycle
+- **确定性路由**: 静态最短路径路由，无动态路由
+- **无活锁/饿死**: 通过 Tag 机制和 Round-Robin 仲裁保证公平性
+- **可配置容量**: TileReg 大小可通过参数配置（默认 1MB）
+
+---
+
+## 2. 顶层架构
+
+### 2.1 系统框图
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │                   TMU                       │
+                    │                                             │
+  Vector port0 ──── │── node0 ──── pipe0 (128KB SRAM)            │
+  Cube   port0 ──── │── node1 ──── pipe1 (128KB SRAM)            │
+  Vector port1 ──── │── node2 ──── pipe2 (128KB SRAM)            │
+  Cube   port1 ──── │── node3 ──── pipe3 (128KB SRAM)            │
+  Vector port2 ──── │── node4 ──── pipe4 (128KB SRAM)            │
+  TMA    port0 ──── │── node5 ──── pipe5 (128KB SRAM)            │
+  BCC/CSU      ──── │── node6 ──── pipe6 (128KB SRAM)            │
+  TMA    port1 ──── │── node7 ──── pipe7 (128KB SRAM)            │
+                    │                                             │
+                    │     Ring Interconnect (CW/CC)               │
+                    └─────────────────────────────────────────────┘
+```
+
+### 2.2 Node-Pipe 映射关系
+
+| Pipe | Node | 外部连接 | 用途 |
+|------|------|----------|------|
+| pipe0 | node0 | Vector port0 | Vector 内部 load 指令的访问通道 |
+| pipe1 | node1 | Cube port0 | Cube 的读数据通道 |
+| pipe2 | node2 | Vector port1 | Vector 内部 load 指令的访问通道 |
+| pipe3 | node3 | Cube port1 | Cube 的写数据通道 |
+| pipe4 | node4 | Vector port2 | Vector 内部 store 指令的访问通道 |
+| pipe5 | node5 | TMA port0 | TMA 读数据通道（TStore: TileReg -> DDR） |
+| pipe6 | node6 | BCC/CSU | 预留给 BCC 命令/响应或 CSU |
+| pipe7 | node7 | TMA port1 | TMA 写数据通道（TLoad: DDR -> TileReg） |
+
+### 2.3 每个 CS (Station) 的能力
+
+- 每个 CS 支持挂载**最多 3 个节点**（当前实现每个 CS 挂载 1 个节点）
+- 每个 CS 支持**同拍上下 Ring**（请求 Ring 和响应 Ring 完全独立并行）
+- 每个 CS 可同时向 CW 和 CC 两个方向各发出/接收一个 flit
+
+---
+
+## 3. Ring 互联网络
+
+### 3.1 拓扑结构
+
+Ring 采用**双向环形拓扑**，8 个 station 按以下物理顺序连接：
+
+```
+RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]
+```
+
+即 node 之间的连接关系为：
+
+```
+node0 <-> node1 <-> node3 <-> node5 <-> node7 <-> node6 <-> node4 <-> node2 <-> node0
+```
+
+用环形图表示：
+
+```
+            node0
+           /     \
+        node2     node1
+        |             |
+        node4     node3
+        |             |
+        node6     node5
+           \     /
+            node7
+```
+
+### 3.2 双向车道
+
+Ring 支持两个方向的数据流动：
+
+| 方向 | 缩写 | 含义 |
+|------|------|------|
+| Clockwise | CW | 顺时针方向：沿 RING_ORDER 正序流动 (0→1→3→5→7→6→4→2→0) |
+| Counter-Clockwise | CC | 逆时针方向：沿 RING_ORDER 逆序流动 (0→2→4→6→7→5→3→1→0) |
+
+### 3.3 独立 Ring 通道
+
+TMU 内部包含**四条独立的 Ring 通道**：
+
+| Ring 通道 | 方向 | 用途 |
+|-----------|------|------|
+| req_cw | CW | 请求 Ring 顺时针通道 |
+| req_cc | CC | 请求 Ring 逆时针通道 |
+| rsp_cw | CW | 响应 Ring 顺时针通道 |
+| rsp_cc | CC | 响应 Ring 逆时针通道 |
+
+请求 Ring 和响应 Ring 完全解耦，可并行工作。
+
+### 3.4 路由策略
+
+采用**静态最短路径路由**，在编译时预计算每对 (src, dst) 的最优方向：
+
+```python
+CW_PREF[src][dst] = 1  # 如果 CW 方向跳数 <= CC 方向跳数
+CW_PREF[src][dst] = 0  # 如果 CC 方向跳数更短
+```
+
+**路由规则**：
+- 不允许动态路由
+- 当 CW 和 CC 距离相等时，优先选择 CW
+- 路由方向在请求注入 Ring 时确定，传输过程中不改变
+
+### 3.5 Ring 跳数表
+
+基于 RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]，各 node 之间的 Ring 跳数（最短路径）：
+
+| src\dst | n0 | n1 | n2 | n3 | n4 | n5 | n6 | n7 |
+|---------|----|----|----|----|----|----|----|----|
+| **n0** | 0 | 1 | 1 | 2 | 2 | 3 | 3 | 4 |
+| **n1** | 1 | 0 | 2 | 1 | 3 | 2 | 4 | 3 |
+| **n2** | 1 | 2 | 0 | 3 | 1 | 4 | 2 | 3 |
+| **n3** | 2 | 1 | 3 | 0 | 4 | 1 | 3 | 2 |
+| **n4** | 2 | 3 | 1 | 4 | 0 | 3 | 1 | 2 |
+| **n5** | 3 | 2 | 4 | 1 | 3 | 0 | 2 | 1 |
+| **n6** | 3 | 4 | 2 | 3 | 1 | 2 | 0 | 1 |
+| **n7** | 4 | 3 | 3 | 2 | 2 | 1 | 1 | 0 |
+
+---
+
+## 4. Flit 格式
+
+### 4.1 数据粒度
+
+Ring 上传输的数据粒度为 **256 Bytes**（一个 cacheline），由 32 个 64-bit word 组成：
+
+```
+Flit Data = 32 x 64-bit words = 256 Bytes
+```
+
+### 4.2 请求 Flit Meta 格式
+
+请求 flit 的 meta 信息打包在一个 64-bit 字段中：
+
+```
+[63                                    REQ_ADDR_LSB] [REQ_TAG_LSB] [REQ_DST_LSB] [REQ_SRC_LSB] [0]
+|<------------- addr (20b) ---------->|<- tag (8b) ->|<- dst (3b) ->|<- src (3b) ->|<- write (1b) ->|
+```
+
+| 字段 | 位宽 | LSB | 含义 |
+|------|------|-----|------|
+| write | 1 | 0 | 读/写标志（1=写，0=读） |
+| src | 3 (node_bits) | 1 | 源节点编号 |
+| dst | 3 (node_bits) | 4 | 目的节点编号（= pipe 编号） |
+| tag | 8 | 7 | 请求标签，用于匹配响应 |
+| addr | 20 (addr_bits) | 15 | 字节地址 |
+
+### 4.3 响应 Flit Meta 格式
+
+```
+[63                    RSP_TAG_LSB] [RSP_DST_LSB] [RSP_SRC_LSB] [0]
+|<-------- tag (8b) -------->|<- dst (3b) ->|<- src (3b) ->|<- write (1b) ->|
+```
+
+| 字段 | 位宽 | LSB | 含义 |
+|------|------|-----|------|
+| write | 1 | 0 | 原始请求的读/写标志 |
+| src | 3 | 1 | 响应源（= pipe 编号） |
+| dst | 3 | 4 | 响应目的（= 原始请求的 src） |
+| tag | 8 | 7 | 原始请求的 tag，原样返回 |
+
+---
+
+## 5. TileReg 存储结构
+
+### 5.1 容量与划分
+
+TileReg 是 TMU 管理的片上 SRAM 缓冲区：
+
+- **默认总容量**: 1MB (1,048,576 Bytes)，可通过 `tile_bytes` 参数配置
+- **划分方式**: 均分为 8 个 **pipe**，每个 pipe 对应一块独立 SRAM
+- **每 pipe 容量**: tile_bytes / 8 = 128KB（默认配置下）
+- **每 pipe 行数**: pipe_bytes / 256 = 512 行（默认配置下）
+- **每行大小**: 256 Bytes = 32 x 64-bit words
+
+```
+TileReg (1MB)
+├── pipe0: 128KB SRAM (512 lines x 256B)  ── node0
+├── pipe1: 128KB SRAM (512 lines x 256B)  ── node1
+├── pipe2: 128KB SRAM (512 lines x 256B)  ── node2
+├── pipe3: 128KB SRAM (512 lines x 256B)  ── node3
+├── pipe4: 128KB SRAM (512 lines x 256B)  ── node4
+├── pipe5: 128KB SRAM (512 lines x 256B)  ── node5
+├── pipe6: 128KB SRAM (512 lines x 256B)  ── node6
+└── pipe7: 128KB SRAM (512 lines x 256B)  ── node7
+```
+
+每个 pipe 内部由 32 个独立的 `byte_mem` 实例组成（每个 word 一个），支持单周期读写。
+
+### 5.2 地址编码
+
+以 1MB 容量为例，使用 20-bit 字节地址：
+
+```
+地址格式: [19:11] [10:8] [7:0]
+           index   pipe   offset
+           9-bit   3-bit  8-bit
+```
+
+| 字段 | 位域 | 位宽 | 含义 |
+|------|------|------|------|
+| offset | [7:0] | 8 | 256B cacheline 内部的字节偏移 |
+| pipe | [10:8] | 3 | 目标 pipe 编号（0~7），决定数据存储在哪个 SRAM |
+| index | [19:11] | 9 | cacheline 在对应 pipe 中的行号（0~511） |
+
+**地址解码过程**：
+1. 从请求地址中提取 `pipe = addr[10:8]`，确定目标 pipe（同时也是目标 node）
+2. 提取 `index = addr[19:11]`，确定 pipe 内的行号
+3. `offset = addr[7:0]` 在当前实现中用于 256B 粒度内的字节定位
+
+### 5.3 可配置性
+
+| 参数 | 默认值 | 约束 |
+|------|--------|------|
+| `tile_bytes` | 1MB (2^20) | 必须是 8 x 256 = 2048 的整数倍 |
+| `tag_bits` | 8 | 请求标签位宽 |
+| `spb_depth` | 4 | SPB FIFO 深度 |
+| `mgb_depth` | 4 | MGB FIFO 深度 |
+
+地址位宽根据 `tile_bytes` 自动计算：
+```
+addr_bits = ceil(log2(tile_bytes))    # 20 for 1MB
+offset_bits = ceil(log2(256)) = 8
+pipe_bits = ceil(log2(8)) = 3
+index_bits = addr_bits - offset_bits - pipe_bits  # 9 for 1MB
+```
+
+---
+
+## 6. 节点微架构
+
+每个 node 包含以下组件：
+
+```
+                          ┌──────────────────────────────────┐
+                          │           Node i                  │
+                          │                                   │
+  外部请求 ──req_valid──> │  ┌─────────┐    ┌─────────┐      │
+  (valid/ready)           │  │ SPB_CW  │    │ SPB_CC  │      │
+  req_write ────────────> │  │ depth=4 │    │ depth=4 │      │
+  req_addr ─────────────> │  │ 1W2R    │    │ 1W2R    │      │
+  req_tag ──────────────> │  └────┬────┘    └────┬────┘      │
+  req_data[0:31] ───────> │       │              │            │
+  <──── req_ready ─────── │       v              v            │
+                          │   ┌──────────────────────┐        │
+                          │   │   Request Ring       │        │
+                          │   │   CW/CC 注入/转发    │        │
+                          │   └──────────────────────┘        │
+                          │                                   │
+                          │   ┌──────────────────────┐        │
+                          │   │   Pipe SRAM          │        │
+                          │   │   (32 x byte_mem)    │        │
+                          │   └──────────────────────┘        │
+                          │                                   │
+                          │   ┌──────────────────────┐        │
+                          │   │   Response Ring      │        │
+                          │   │   CW/CC 注入/转发    │        │
+                          │   └──────────────────────┘        │
+                          │       │              │            │
+                          │  ┌────┴────┐    ┌────┴────┐      │
+                          │  │ MGB_CW  │    │ MGB_CC  │      │
+                          │  │ depth=4 │    │ depth=4 │      │
+                          │  │ 2W1R    │    │ 2W1R    │      │
+                          │  └────┬────┘    └────┬────┘      │
+                          │       │    RR 仲裁    │           │
+                          │       └──────┬───────┘            │
+  <──── resp_valid ────── │              │                    │
+  <──── resp_tag ──────── │              v                    │
+  <──── resp_data[0:31] ─ │         resp output               │
+  <──── resp_is_write ─── │                                   │
+  ──── resp_ready ──────> │                                   │
+                          └──────────────────────────────────┘
+```
+
+### 6.1 节点外部接口
+
+每个 node 对外暴露以下信号：
+
+**请求通道（外部 -> TMU）**：
+
+| 信号 | 位宽 | 方向 | 含义 |
+|------|------|------|------|
+| `n{i}_req_valid` | 1 | input | 请求有效 |
+| `n{i}_req_write` | 1 | input | 1=写请求，0=读请求 |
+| `n{i}_req_addr` | 20 | input | 字节地址 |
+| `n{i}_req_tag` | 8 | input | 请求标签（用于匹配响应） |
+| `n{i}_req_data_w{0..31}` | 64 each | input | 写数据（32 个 64-bit word） |
+| `n{i}_req_ready` | 1 | output | 请求就绪（反压信号） |
+
+**响应通道（TMU -> 外部）**：
+
+| 信号 | 位宽 | 方向 | 含义 |
+|------|------|------|------|
+| `n{i}_resp_valid` | 1 | output | 响应有效 |
+| `n{i}_resp_tag` | 8 | output | 响应标签（与请求 tag 匹配） |
+| `n{i}_resp_data_w{0..31}` | 64 each | output | 响应数据 |
+| `n{i}_resp_is_write` | 1 | output | 标识原始请求是否为写操作 |
+| `n{i}_resp_ready` | 1 | input | 外部准备好接收响应 |
+
+**握手协议**: 标准 valid/ready 握手。当 `valid & ready` 同时为高时，传输发生。
+
+---
+
+## 7. SPB (Send/Post Buffer)
+
+### 7.1 功能概述
+
+SPB 是请求上 Ring 的缓冲区，位于每个 node 的请求注入端。每个 node 有两个 SPB：
+- **SPB_CW**: 缓存将要向 CW 方向发送的请求
+- **SPB_CC**: 缓存将要向 CC 方向发送的请求
+
+### 7.2 SPB 规格
+
+| 参数 | 值 |
+|------|-----|
+| 深度 | 4 entries |
+| 端口 | 1 写 2 读（一拍可同时 pick CW 和 CC 各一个请求上 Ring） |
+| Bypass | **不支持** bypass SPB 上 Ring（请求必须先入 SPB 再注入 Ring） |
+| 反压 | SPB 满时，`req_ready` 拉低，反压外部请求 |
+
+### 7.3 SPB 工作流程
+
+1. 外部请求到达 node，根据 `CW_PREF[src][dst]` 确定方向
+2. 请求被写入对应方向的 SPB（CW 或 CC）
+3. 当 Ring 对应方向的 slot 空闲时，SPB 头部的请求被注入 Ring
+4. Ring 上已有 flit 优先前递（forward），SPB 注入优先级低于 Ring 转发
+
+### 7.4 SPB 注入仲裁
+
+```
+if ring_slot_has_flit:
+    forward flit (优先)
+    SPB 不注入
+else:
+    if SPB 非空 and 目的不是本地:
+        注入 SPB 头部请求到 Ring
+```
+
+**本地请求优化**: 如果 SPB 头部请求的目的 node 就是本 node（即 src == dst），则该请求直接被弹出送往本地 pipe，不经过 Ring 传输。
+
+---
+
+## 8. MGB (Merge Buffer)
+
+### 8.1 功能概述
+
+MGB 是响应下 Ring 的缓冲区，位于每个 node 的响应接收端。每个 node 有两个 MGB：
+- **MGB_CW**: 缓存从 CW 方向到达的响应
+- **MGB_CC**: 缓存从 CC 方向到达的响应
+
+### 8.2 MGB 规格
+
+| 参数 | 值 |
+|------|-----|
+| 深度 | 4 entries |
+| 端口 | 2 写 1 读（一拍可同时接收 CW 和 CC 各一个 flit，单路出队） |
+| Bypass | **支持** bypass 下 Ring（队列为空且仅一个方向到达时可 bypass） |
+| 反压 | MGB 满时，反压 Ring 上的响应注入 |
+
+### 8.3 MGB Bypass 机制
+
+当满足以下条件时，响应可以 bypass MGB 直接输出：
+- MGB 队列为空
+- 仅有一个方向（CW 或 CC）有到达的响应
+- 外部 `resp_ready` 为高
+
+### 8.4 MGB 出队仲裁
+
+当 CW 和 CC 两个 MGB 都有数据时，采用 **Round-Robin (RR)** 仲裁：
+
+```
+rr_reg: 1-bit 寄存器，每次出队后翻转
+if only CW has data:  pick CW
+if only CC has data:  pick CC
+if both have data:    rr_reg==0 ? pick CW : pick CC
+```
+
+RR 仲裁确保两个方向的响应不会饿死。
+
+---
+
+## 9. 请求 Ring 数据通路
+
+### 9.1 请求处理流水线
+
+```
+外部请求 → SPB入队(1 cycle) → Ring传输(N hops) → Pipe SRAM访问(1 cycle) → 响应注入
+```
+
+### 9.2 请求 Ring 每站逻辑
+
+对于 Ring 上的每个 station（按 RING_ORDER 遍历），每拍执行以下逻辑：
+
+**Step 1: 检查到达的 Ring flit**
+```
+cw_in = 从 CW 方向前一站到达的 flit
+cc_in = 从 CC 方向后一站到达的 flit
+```
+
+**Step 2: 判断是否为本地请求（需要弹出到 pipe）**
+```
+ring_cw_local = cw_in.valid AND (cw_in.dst == 本站 node_id)
+ring_cc_local = cc_in.valid AND (cc_in.dst == 本站 node_id)
+spb_cw_local  = spb_cw.valid AND (spb_cw.dst == 本站 node_id)
+spb_cc_local  = spb_cc.valid AND (spb_cc.dst == 本站 node_id)
+```
+
+**Step 3: 优先级仲裁（弹出到 pipe）**
+```
+优先级从高到低:
+1. Ring CW 方向到达的本地请求
+2. Ring CC 方向到达的本地请求
+3. SPB CW 中目的为本地的请求
+4. SPB CC 中目的为本地的请求
+```
+
+**Step 4: Ring 转发与 SPB 注入**
+```
+CW 方向:
+  if cw_in 非本地: 转发 cw_in（优先）
+  else if SPB_CW 非空且非本地: 注入 SPB_CW 头部
+
+CC 方向:
+  if cc_in 非本地: 转发 cc_in（优先）
+  else if SPB_CC 非空且非本地: 注入 SPB_CC 头部
+```
+
+---
+
+## 10. Pipe SRAM 访问
+
+### 10.1 Pipe Stage 寄存器
+
+从请求 Ring 弹出的请求先经过一级 **pipe stage 寄存器**（1 cycle 延迟），然后访问 SRAM：
+
+```
+pipe_req_valid → [pipe_stage_valid reg] → SRAM 读/写
+pipe_req_meta  → [pipe_stage_meta  reg] → 地址解码
+pipe_req_data  → [pipe_stage_data  reg] → 写数据
+```
+
+### 10.2 SRAM 读写操作
+
+**写操作**:
+- 条件: `pipe_stage_valid & write`
+- 将 32 个 64-bit word 写入对应 pipe 的 SRAM
+- 写掩码: 全字节写入 (wstrb = 0xFF)
+- 响应数据: 返回写入的数据本身
+
+**读操作**:
+- 条件: `pipe_stage_valid & ~write`
+- 从对应 pipe 的 SRAM 读出 32 个 64-bit word
+- 响应数据: 返回读出的数据
+
+### 10.3 响应生成
+
+SRAM 访问完成后，生成响应 flit：
+```
+rsp_meta = pack(write, src=pipe_id, dst=原始请求的src, tag=原始请求的tag)
+rsp_data = write ? 写入数据 : 读出数据
+rsp_dir  = CW_PREF[pipe_id][原始请求的src]  # 响应方向
+```
+
+响应被送入对应方向的响应注入 FIFO（深度=4），等待注入响应 Ring。
+
+---
+
+## 11. 响应 Ring 数据通路
+
+### 11.1 响应 Ring 每站逻辑
+
+与请求 Ring 类似，但弹出目标是 MGB 而非 pipe：
+
+**Step 1: 检查到达的 Ring flit**
+```
+cw_in = 从 CW 方向前一站到达的响应 flit
+cc_in = 从 CC 方向后一站到达的响应 flit
+```
+
+**Step 2: 判断是否为本地响应**
+```
+ring_cw_local = cw_in.valid AND (cw_in.dst == 本站 node_id)
+ring_cc_local = cc_in.valid AND (cc_in.dst == 本站 node_id)
+```
+
+**Step 3: 本地响应送入 MGB**
+```
+cw_local = ring_cw_local OR rsp_inject_cw_local
+cc_local = ring_cc_local OR rsp_inject_cc_local
+→ 分别送入 MGB_CW 和 MGB_CC
+```
+
+**Step 4: Ring 转发与响应注入**
+```
+CW 方向:
+  if cw_in 非本地: 转发（优先）
+  else if rsp_inject_cw 非空且非本地: 注入
+
+CC 方向:
+  if cc_in 非本地: 转发（优先）
+  else if rsp_inject_cc 非空且非本地: 注入
+```
+
+### 11.2 MGB 出队到外部
+
+```
+MGB_CW 和 MGB_CC 通过 RR 仲裁选择一个输出
+→ resp_valid, resp_tag, resp_data, resp_is_write
+← resp_ready (外部反压)
+```
+
+---
+
+## 12. 时序分析
+
+### 12.1 延迟模型
+
+一次完整的读/写操作延迟由以下阶段组成：
+
+| 阶段 | 延迟 | 说明 |
+|------|------|------|
+| SPB 入队 | 1 cycle | 请求写入 SPB |
+| 请求 Ring 传输 | H hops | H = src 到 dst 的最短跳数 |
+| Pipe Stage | 1 cycle | pipe stage 寄存器 |
+| SRAM 访问 | 0 cycle | 与 pipe stage 同拍完成 |
+| 响应 Ring 传输 | H hops | H = dst 到 src 的最短跳数（与请求相同） |
+| MGB bypass/出队 | 1 cycle | 响应输出（bypass 时为 0） |
+
+**总延迟公式**: `Latency = 4 + 2 * H` cycles（最优情况，无竞争）
+
+其中 H 为 Ring 上的跳数。
+
+### 12.2 典型延迟示例
+
+**最短路径示例（Vector 访问 pipe2，H=1）**:
+
+```
+Cycle 1: Vector 请求到达 node2 → SPB 入队
+Cycle 2: SPB 注入请求 Ring → 请求到达 node2（本地，H=0 实际上是自访问）
+Cycle 3: Pipe stage 寄存器 + SRAM 访问
+Cycle 4: 响应 bypass MGB 输出 → 数据可用
+总延迟: 4 cycles
+```
+
+**跨节点示例（node0 访问 pipe2，H=1）**:
+
+```
+Cycle 1: node0 请求 → SPB 入队
+Cycle 2: SPB 注入请求 Ring（CC 方向，node0→node2 跳 1 hop）
+Cycle 3: 请求到达 node2 → 弹出到 pipe2 → pipe stage
+Cycle 4: SRAM 访问完成 → 响应注入响应 Ring
+Cycle 5: 响应传输 1 hop（node2→node0）
+Cycle 6: 响应到达 node0 → MGB bypass 输出
+总延迟: 6 cycles = 4 + 2*1
+```
+
+**远距离示例（node0 访问 pipe7，H=4）**:
+
+```
+总延迟: 4 + 2*4 = 12 cycles
+```
+
+### 12.3 各 node 自访问延迟
+
+| 操作 | 延迟 |
+|------|------|
+| node_i 访问 pipe_i（自身 pipe） | 4 cycles |
+| node_i 访问相邻 pipe（H=1） | 6 cycles |
+| node_i 访问 H=2 的 pipe | 8 cycles |
+| node_i 访问 H=3 的 pipe | 10 cycles |
+| node_i 访问 H=4 的 pipe（最远） | 12 cycles |
+
+---
+
+## 13. 反压与流控
+
+### 13.1 请求侧反压
+
+```
+req_ready = dir_cw ? SPB_CW.in_ready : SPB_CC.in_ready
+```
+
+当对应方向的 SPB 满（4 entries）时，`req_ready` 拉低，外部请求被阻塞。
+
+### 13.2 Ring 反压
+
+Ring 上的 flit 转发优先于 SPB 注入。当 Ring slot 被占用时，SPB 无法注入，但不会丢失数据（SPB 保持 flit 直到 slot 空闲）。
+
+### 13.3 响应侧反压
+
+MGB 满时，Ring 上到达本站的响应无法弹出，会继续在 Ring 上流转（实际上会阻塞 Ring 转发）。
+
+外部 `resp_ready` 为低时，MGB 不出队，可能导致 MGB 满。
+
+---
+
+## 14. 防活锁/饿死机制
+
+### 14.1 Tag 机制
+
+- 每个请求携带 8-bit tag，响应原样返回
+- Tag 用于请求-响应匹配，确保外部可以区分不同请求的响应
+- Tag 不参与 Ring 路由决策
+
+### 14.2 FIFO 顺序保证
+
+- SPB 和 MGB 均为 FIFO 结构，保证同方向的请求/响应按序处理
+- 避免了乱序导致的活锁问题
+
+### 14.3 Round-Robin 仲裁
+
+- MGB 出队采用 RR 仲裁，确保 CW 和 CC 两个方向的响应公平出队
+- Pipe 访问时，Ring CW/CC 和 SPB CW/CC 四路请求按固定优先级仲裁
+- Ring 转发优先于 SPB 注入，保证 Ring 上的 flit 不会被无限阻塞
+
+### 14.4 静态路由
+
+- 最短路径静态路由消除了动态路由可能引入的活锁
+- 请求和响应走独立的 Ring，避免请求-响应死锁
+
+---
+
+## 15. 调试接口
+
+TMU 提供以下调试输出信号，用于波形观察和可视化：
+
+| 信号 | 位宽 | 含义 |
+|------|------|------|
+| `dbg_req_cw_v{i}` | 1 | 请求 Ring CW 方向 node_i 处 link 寄存器 valid |
+| `dbg_req_cc_v{i}` | 1 | 请求 Ring CC 方向 node_i 处 link 寄存器 valid |
+| `dbg_req_cw_meta{i}` | variable | 请求 Ring CW 方向 node_i 处 meta 信息 |
+| `dbg_req_cc_meta{i}` | variable | 请求 Ring CC 方向 node_i 处 meta 信息 |
+| `dbg_rsp_cw_v{i}` | 1 | 响应 Ring CW 方向 node_i 处 link 寄存器 valid |
+| `dbg_rsp_cc_v{i}` | 1 | 响应 Ring CC 方向 node_i 处 link 寄存器 valid |
+| `dbg_rsp_cw_meta{i}` | variable | 响应 Ring CW 方向 node_i 处 meta 信息 |
+| `dbg_rsp_cc_meta{i}` | variable | 响应 Ring CC 方向 node_i 处 meta 信息 |
+
+配套工具：
+- `janus/tools/plot_tmu_trace.py`: 将 trace CSV 渲染为 SVG 时序图
+- `janus/tools/animate_tmu_trace.py`: 生成 Ring 拓扑动画 SVG
+- `janus/tools/animate_tmu_ring_vcd.py`: 从 VCD 波形生成 Ring 动画
+
+---
+
+## 16. 实现代码结构
+
+### 16.1 源文件
+
+| 文件 | 用途 |
+|------|------|
+| `janus/pyc/janus/tmu/janus_tmu_pyc.py` | TMU RTL 实现（pyCircuit DSL） |
+| `janus/tb/tb_janus_tmu_pyc.cpp` | C++ cycle-accurate 测试平台 |
+| `janus/tb/tb_janus_tmu_pyc.sv` | SystemVerilog 测试平台 |
+| `janus/tools/run_janus_tmu_pyc_cpp.sh` | C++ 仿真运行脚本 |
+| `janus/tools/run_janus_tmu_pyc_verilator.sh` | Verilator 仿真运行脚本 |
+| `janus/tools/update_tmu_generated.sh` | 重新生成 RTL 脚本 |
+| `janus/generated/janus_tmu_pyc/` | 生成的 Verilog 和 C++ header |
+
+### 16.2 代码关键函数/区域
+
+| 代码区域 | 行号范围 | 功能 |
+|----------|----------|------|
+| `RING_ORDER`, `CW_PREF` | L12-L34 | Ring 拓扑定义与路由表 |
+| `_dir_cw()` | L37-L40 | 运行时路由方向选择 |
+| `_build_bundle_fifo()` | L82-L129 | FIFO bundle 构建（SPB/MGB 共用） |
+| `NodeIo` | L132-L144 | 节点 IO 定义 |
+| `build()` 参数处理 | L147-L177 | 可配置参数与地址位宽计算 |
+| Node IO 实例化 | L203-L232 | 8 个节点的 IO 端口创建 |
+| SPB 构建 | L234-L290 | 每节点 CW/CC 两个 SPB |
+| Ring link 寄存器 | L292-L331 | 请求/响应 Ring 的 link 寄存器 |
+| 请求 Ring 遍历 | L338-L408 | 请求 Ring 每站逻辑（弹出/转发/注入） |
+| Pipe stage 寄存器 | L410-L426 | Pipe 访问前的寄存器级 |
+| 响应注入 FIFO | L428-L503 | Pipe 访问后的响应注入缓冲 |
+| 响应 Ring 遍历 | L505-L630 | 响应 Ring 每站逻辑 + MGB |
+| 调试输出 | L632-L654 | 调试信号输出 |
+
+---
+
+## 17. 测试验证
+
+### 17.1 基础测试用例
+
+测试平台（`tb_janus_tmu_pyc.cpp` / `tb_janus_tmu_pyc.sv`）包含以下测试：
+
+**Test 1: 本地读写（每个 node 访问自身 pipe）**
+```
+for each node n in [0..7]:
+    1. node_n 写 pipe_n: addr = makeAddr(n, n, 0), data = seed(n+1)
+    2. 等待写响应，验证 tag 和 data 匹配
+    3. node_n 读 pipe_n: 同一地址
+    4. 等待读响应，验证读回数据 == 写入数据
+```
+
+**Test 2: 跨节点读写（node0 访问 pipe2）**
+```
+1. node0 写 pipe2: addr = makeAddr(5, 2, 0), data = seed(0xAA), tag = 0x55
+2. 等待写响应
+3. node0 读 pipe2: 同一地址, tag = 0x56
+4. 等待读响应，验证读回数据 == 写入数据
+```
+
+### 17.2 验证要点
+
+- Tag 匹配：响应的 tag 必须与请求的 tag 一致
+- 数据完整性：读回的 32 个 64-bit word 必须与写入完全一致
+- resp_is_write：正确反映原始请求类型
+- 超时检测：2000 cycle 内未收到响应则报错
+
+---
+
+## 附录 A: CW_PREF 路由偏好表
+
+基于 RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]，预计算的路由偏好（1=CW, 0=CC）：
+
+| src\dst | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---------|---|---|---|---|---|---|---|---|
+| **0** | 1 | 1 | 0 | 1 | 0 | 1 | 0 | 1 |
+| **1** | 0 | 1 | 0 | 1 | 0 | 1 | 0 | 1 |
+| **2** | 1 | 1 | 1 | 1 | 1 | 0 | 1 | 0 |
+| **3** | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 1 |
+| **4** | 1 | 1 | 0 | 1 | 1 | 1 | 0 | 1 |
+| **5** | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 1 |
+| **6** | 1 | 1 | 0 | 1 | 1 | 1 | 1 | 1 |
+| **7** | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 1 |
+
+## 附录 B: 术语表
+
+| 术语 | 全称 | 含义 |
+|------|------|------|
+| TMU | Tile Management Unit | Tile 管理单元 |
+| TileReg | Tile Register File | Tile 寄存器文件（片上 SRAM 缓冲区） |
+| Ring | Ring Interconnect | 环形互联网络 |
+| CS | Circuit Station | 环上的站点 |
+| CW | Clockwise | 顺时针方向 |
+| CC | Counter-Clockwise | 逆时针方向 |
+| SPB | Send/Post Buffer | 发送缓冲区（请求上 Ring） |
+| MGB | Merge Buffer | 合并缓冲区（响应下 Ring） |
+| Flit | Flow control unit | 流控单元（Ring 上传输的最小数据单位） |
+| Pipe | Pipeline SRAM | TileReg 的一个分区（128KB） |
+| BCC | Block Control Core | 块控制核 |
+| TMA | Tile Memory Access | Tile 存储访问单元 |
+| RR | Round-Robin | 轮询仲裁 |

--- a/janus/pyc/janus/tmu/janus_tmu_pyc.py
+++ b/janus/pyc/janus/tmu/janus_tmu_pyc.py
@@ -1,0 +1,657 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from pycircuit import Circuit, Reg, Wire
+from pycircuit.hw import cat
+
+from janus.bcc.ooo.helpers import mux_by_uindex
+
+
+RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]
+NODE_COUNT = 8
+
+
+def _build_cw_pref() -> list[list[int]]:
+    order = RING_ORDER
+    n = len(order)
+    pos = {node: i for i, node in enumerate(order)}
+    prefs: list[list[int]] = [[0 for _ in range(n)] for _ in range(n)]
+    for s in range(n):
+        for d in range(n):
+            if s == d:
+                prefs[s][d] = 1
+                continue
+            s_pos = pos[s]
+            d_pos = pos[d]
+            cw = (d_pos - s_pos) % n
+            cc = (s_pos - d_pos) % n
+            prefs[s][d] = 1 if cw <= cc else 0
+    return prefs
+
+
+CW_PREF = _build_cw_pref()
+
+
+def _dir_cw(m: Circuit, *, src: int, dst: Wire) -> Wire:
+    c = m.const
+    items = [c(1 if CW_PREF[src][i] else 0, width=1) for i in range(NODE_COUNT)]
+    return mux_by_uindex(m, idx=dst, items=items, default=c(1, width=1))
+
+
+def _field(w: Wire, *, lsb: int, width: int) -> Wire:
+    return w.slice(lsb=lsb, width=width)
+
+
+def _and_all(m: Circuit, items: list[Wire]) -> Wire:
+    out = m.const(1, width=1)
+    for it in items:
+        out = out & it
+    return out
+
+
+def _select_words(sel: Wire, a_words: list[Wire], b_words: list[Wire]) -> list[Wire]:
+    return [sel.select(a, b) for a, b in zip(a_words, b_words)]
+
+
+def _select4_words(
+    sel_a: Wire,
+    sel_b: Wire,
+    sel_c: Wire,
+    sel_d: Wire,
+    wa: list[Wire],
+    wb: list[Wire],
+    wc: list[Wire],
+    wd: list[Wire],
+) -> list[Wire]:
+    out: list[Wire] = []
+    for a, b, c, d in zip(wa, wb, wc, wd):
+        out.append(sel_a.select(a, sel_b.select(b, sel_c.select(c, d))))
+    return out
+
+
+@dataclass(frozen=True)
+class BundleFifo:
+    in_ready: Wire
+    out_valid: Wire
+    out_meta: Wire
+    out_data: list[Wire]
+
+
+def _build_bundle_fifo(
+    m: Circuit,
+    *,
+    clk: Wire,
+    rst: Wire,
+    in_valid: Wire,
+    in_meta: Wire,
+    in_data: list[Wire],
+    out_ready: Wire,
+    depth: int,
+    name: str,
+) -> BundleFifo:
+    push = m.named_wire(f"{name}__push", width=1)
+    pop = m.named_wire(f"{name}__pop", width=1)
+
+    meta_in_ready, meta_out_valid, meta_out_data = m.fifo(
+        clk,
+        rst,
+        in_valid=push,
+        in_data=in_meta,
+        out_ready=pop,
+        depth=depth,
+    )
+
+    data_in_ready: list[Wire] = []
+    data_out_valid: list[Wire] = []
+    data_out_data: list[Wire] = []
+
+    for wi, word in enumerate(in_data):
+        in_ready_w, out_valid_w, out_data_w = m.fifo(
+            clk,
+            rst,
+            in_valid=push,
+            in_data=word,
+            out_ready=pop,
+            depth=depth,
+        )
+        data_in_ready.append(in_ready_w)
+        data_out_valid.append(out_valid_w)
+        data_out_data.append(out_data_w)
+
+    bundle_in_ready = _and_all(m, [meta_in_ready, *data_in_ready])
+    bundle_out_valid = _and_all(m, [meta_out_valid, *data_out_valid])
+
+    m.assign(push, in_valid & bundle_in_ready)
+    m.assign(pop, out_ready & bundle_out_valid)
+
+    return BundleFifo(in_ready=bundle_in_ready, out_valid=bundle_out_valid, out_meta=meta_out_data, out_data=data_out_data)
+
+
+@dataclass(frozen=True)
+class NodeIo:
+    req_valid: Wire
+    req_write: Wire
+    req_addr: Wire
+    req_tag: Wire
+    req_data_words: list[Wire]
+    req_ready: Wire
+    resp_ready: Wire
+    resp_valid: Wire
+    resp_tag: Wire
+    resp_data_words: list[Wire]
+    resp_is_write: Wire
+
+
+def build(
+    m: Circuit,
+    *,
+    tile_bytes: int | None = None,
+    tag_bits: int = 8,
+    spb_depth: int = 4,
+    mgb_depth: int = 4,
+) -> None:
+    if tile_bytes is None:
+        tile_bytes = int(os.getenv("JANUS_TMU_TILE_BYTES", 1 << 20))
+    if tile_bytes <= 0:
+        raise ValueError("tile_bytes must be > 0")
+
+    line_bytes = 256
+    line_words = line_bytes // 8
+    pipe_count = NODE_COUNT
+
+    if tile_bytes % (pipe_count * line_bytes) != 0:
+        raise ValueError("tile_bytes must be divisible by 8 * 256")
+
+    addr_bits = (tile_bytes - 1).bit_length()
+    offset_bits = (line_bytes - 1).bit_length()
+    pipe_bits = (pipe_count - 1).bit_length()
+    if addr_bits < offset_bits + pipe_bits:
+        raise ValueError("tile_bytes too small for pipe addressing")
+
+    index_bits = addr_bits - offset_bits - pipe_bits
+    lines_per_pipe = tile_bytes // (pipe_count * line_bytes)
+
+    c = m.const
+    node_bits = pipe_bits
+
+    clk = m.clock("clk")
+    rst = m.reset("rst")
+
+    # Meta layouts (packed into 64-bit).
+    REQ_WRITE_LSB = 0
+    REQ_SRC_LSB = REQ_WRITE_LSB + 1
+    REQ_DST_LSB = REQ_SRC_LSB + node_bits
+    REQ_TAG_LSB = REQ_DST_LSB + node_bits
+    REQ_ADDR_LSB = REQ_TAG_LSB + tag_bits
+
+    RSP_WRITE_LSB = 0
+    RSP_SRC_LSB = RSP_WRITE_LSB + 1
+    RSP_DST_LSB = RSP_SRC_LSB + node_bits
+    RSP_TAG_LSB = RSP_DST_LSB + node_bits
+
+    def pack_req_meta(write: Wire, src: Wire, dst: Wire, tag: Wire, addr: Wire) -> Wire:
+        meta = cat(addr, tag, dst, src, write)
+        return meta.zext(width=64)
+
+    def pack_rsp_meta(write: Wire, src: Wire, dst: Wire, tag: Wire) -> Wire:
+        meta = cat(tag, dst, src, write)
+        return meta.zext(width=64)
+
+    # --- Node IOs ---
+    nodes: list[NodeIo] = []
+    for i in range(NODE_COUNT):
+        req_valid = m.input(f"n{i}_req_valid", width=1)
+        req_write = m.input(f"n{i}_req_write", width=1)
+        req_addr = m.input(f"n{i}_req_addr", width=addr_bits)
+        req_tag = m.input(f"n{i}_req_tag", width=tag_bits)
+        req_data_words = [m.input(f"n{i}_req_data_w{wi}", width=64) for wi in range(line_words)]
+        resp_ready = m.input(f"n{i}_resp_ready", width=1)
+
+        req_ready = m.named_wire(f"n{i}_req_ready", width=1)
+        resp_valid = m.named_wire(f"n{i}_resp_valid", width=1)
+        resp_tag = m.named_wire(f"n{i}_resp_tag", width=tag_bits)
+        resp_data_words = [m.named_wire(f"n{i}_resp_data_w{wi}", width=64) for wi in range(line_words)]
+        resp_is_write = m.named_wire(f"n{i}_resp_is_write", width=1)
+
+        nodes.append(
+            NodeIo(
+                req_valid=req_valid,
+                req_write=req_write,
+                req_addr=req_addr,
+                req_tag=req_tag,
+                req_data_words=req_data_words,
+                req_ready=req_ready,
+                resp_ready=resp_ready,
+                resp_valid=resp_valid,
+                resp_tag=resp_tag,
+                resp_data_words=resp_data_words,
+                resp_is_write=resp_is_write,
+            )
+        )
+
+    # --- Build SPB bundles per node (cw/cc) ---
+    spb_cw: list[BundleFifo] = []
+    spb_cc: list[BundleFifo] = []
+    spb_cw_out_ready: list[Wire] = []
+    spb_cc_out_ready: list[Wire] = []
+
+    req_meta: list[Wire] = []
+    req_words: list[list[Wire]] = []
+    req_dir_cw: list[Wire] = []
+
+    for i, node in enumerate(nodes):
+        dst = node.req_addr.slice(lsb=offset_bits, width=pipe_bits)
+        src = c(i, width=node_bits)
+        meta = pack_req_meta(node.req_write, src, dst, node.req_tag, node.req_addr)
+        req_meta.append(meta)
+        words = node.req_data_words
+        req_words.append(words)
+
+        dir_cw = _dir_cw(m, src=i, dst=dst)
+        req_dir_cw.append(dir_cw)
+
+        in_valid_cw = node.req_valid & dir_cw
+        in_valid_cc = node.req_valid & (~dir_cw)
+
+        cw_ready = m.named_wire(f"spb{i}_cw_out_ready", width=1)
+        cc_ready = m.named_wire(f"spb{i}_cc_out_ready", width=1)
+        spb_cw_out_ready.append(cw_ready)
+        spb_cc_out_ready.append(cc_ready)
+
+        spb_cw.append(
+            _build_bundle_fifo(
+                m,
+                clk=clk,
+                rst=rst,
+                in_valid=in_valid_cw,
+                in_meta=meta,
+                in_data=words,
+                out_ready=cw_ready,
+                depth=spb_depth,
+                name=f"spb{i}_cw",
+            )
+        )
+        spb_cc.append(
+            _build_bundle_fifo(
+                m,
+                clk=clk,
+                rst=rst,
+                in_valid=in_valid_cc,
+                in_meta=meta,
+                in_data=words,
+                out_ready=cc_ready,
+                depth=spb_depth,
+                name=f"spb{i}_cc",
+            )
+        )
+
+        m.assign(node.req_ready, dir_cw.select(spb_cw[i].in_ready, spb_cc[i].in_ready))
+
+    # --- Ring link registers (request + response, cw/cc) ---
+    req_cw_link_valid: list[Reg] = []
+    req_cw_link_meta: list[Reg] = []
+    req_cw_link_data: list[list[Reg]] = []
+    req_cc_link_valid: list[Reg] = []
+    req_cc_link_meta: list[Reg] = []
+    req_cc_link_data: list[list[Reg]] = []
+
+    rsp_cw_link_valid: list[Reg] = []
+    rsp_cw_link_meta: list[Reg] = []
+    rsp_cw_link_data: list[list[Reg]] = []
+    rsp_cc_link_valid: list[Reg] = []
+    rsp_cc_link_meta: list[Reg] = []
+    rsp_cc_link_data: list[list[Reg]] = []
+
+    with m.scope("req_ring"):
+        for i in range(NODE_COUNT):
+            req_cw_link_valid.append(m.out(f"cw_v{i}", clk=clk, rst=rst, width=1, init=0, en=1))
+            req_cw_link_meta.append(m.out(f"cw_m{i}", clk=clk, rst=rst, width=64, init=0, en=1))
+            req_cw_link_data.append(
+                [m.out(f"cw_d{i}_w{wi}", clk=clk, rst=rst, width=64, init=0, en=1) for wi in range(line_words)]
+            )
+            req_cc_link_valid.append(m.out(f"cc_v{i}", clk=clk, rst=rst, width=1, init=0, en=1))
+            req_cc_link_meta.append(m.out(f"cc_m{i}", clk=clk, rst=rst, width=64, init=0, en=1))
+            req_cc_link_data.append(
+                [m.out(f"cc_d{i}_w{wi}", clk=clk, rst=rst, width=64, init=0, en=1) for wi in range(line_words)]
+            )
+
+    with m.scope("rsp_ring"):
+        for i in range(NODE_COUNT):
+            rsp_cw_link_valid.append(m.out(f"cw_v{i}", clk=clk, rst=rst, width=1, init=0, en=1))
+            rsp_cw_link_meta.append(m.out(f"cw_m{i}", clk=clk, rst=rst, width=64, init=0, en=1))
+            rsp_cw_link_data.append(
+                [m.out(f"cw_d{i}_w{wi}", clk=clk, rst=rst, width=64, init=0, en=1) for wi in range(line_words)]
+            )
+            rsp_cc_link_valid.append(m.out(f"cc_v{i}", clk=clk, rst=rst, width=1, init=0, en=1))
+            rsp_cc_link_meta.append(m.out(f"cc_m{i}", clk=clk, rst=rst, width=64, init=0, en=1))
+            rsp_cc_link_data.append(
+                [m.out(f"cc_d{i}_w{wi}", clk=clk, rst=rst, width=64, init=0, en=1) for wi in range(line_words)]
+            )
+
+    # --- Pipe request wires ---
+    pipe_req_valid: list[Wire] = [c(0, width=1) for _ in range(NODE_COUNT)]
+    pipe_req_meta: list[Wire] = [c(0, width=64) for _ in range(NODE_COUNT)]
+    pipe_req_data: list[list[Wire]] = [[c(0, width=64) for _ in range(line_words)] for _ in range(NODE_COUNT)]
+
+    # --- Request ring traversal + ejection to pipes ---
+    for pos in range(NODE_COUNT):
+        nid = RING_ORDER[pos]
+        node_const = c(nid, width=node_bits)
+
+        prev_pos = (pos - 1) % NODE_COUNT
+        next_pos = (pos + 1) % NODE_COUNT
+
+        cw_in_valid = req_cw_link_valid[prev_pos].out()
+        cw_in_meta = req_cw_link_meta[prev_pos].out()
+        cw_in_data = [r.out() for r in req_cw_link_data[prev_pos]]
+
+        cc_in_valid = req_cc_link_valid[next_pos].out()
+        cc_in_meta = req_cc_link_meta[next_pos].out()
+        cc_in_data = [r.out() for r in req_cc_link_data[next_pos]]
+
+        cw_in_dst = _field(cw_in_meta, lsb=REQ_DST_LSB, width=node_bits)
+        cc_in_dst = _field(cc_in_meta, lsb=REQ_DST_LSB, width=node_bits)
+
+        ring_cw_local = cw_in_valid & cw_in_dst.eq(node_const)
+        ring_cc_local = cc_in_valid & cc_in_dst.eq(node_const)
+
+        spb_cw_head_meta = spb_cw[nid].out_meta
+        spb_cc_head_meta = spb_cc[nid].out_meta
+        spb_cw_head_data = spb_cw[nid].out_data
+        spb_cc_head_data = spb_cc[nid].out_data
+
+        spb_cw_dst = _field(spb_cw_head_meta, lsb=REQ_DST_LSB, width=node_bits)
+        spb_cc_dst = _field(spb_cc_head_meta, lsb=REQ_DST_LSB, width=node_bits)
+
+        spb_cw_local = spb_cw[nid].out_valid & spb_cw_dst.eq(node_const)
+        spb_cc_local = spb_cc[nid].out_valid & spb_cc_dst.eq(node_const)
+
+        sel_ring_cw = ring_cw_local
+        sel_ring_cc = (~sel_ring_cw) & ring_cc_local
+        sel_spb_cw = (~sel_ring_cw) & (~sel_ring_cc) & spb_cw_local
+        sel_spb_cc = (~sel_ring_cw) & (~sel_ring_cc) & (~sel_spb_cw) & spb_cc_local
+
+        pipe_req_valid[nid] = sel_ring_cw | sel_ring_cc | sel_spb_cw | sel_spb_cc
+        pipe_req_meta[nid] = sel_ring_cw.select(
+            cw_in_meta,
+            sel_ring_cc.select(cc_in_meta, sel_spb_cw.select(spb_cw_head_meta, spb_cc_head_meta)),
+        )
+        pipe_req_data[nid] = _select4_words(sel_ring_cw, sel_ring_cc, sel_spb_cw, sel_spb_cc, cw_in_data, cc_in_data, spb_cw_head_data, spb_cc_head_data)
+
+        cw_forward_valid = cw_in_valid & (~sel_ring_cw)
+        cw_can_inject = ~cw_forward_valid
+        cw_inject_valid = spb_cw[nid].out_valid & (~spb_cw_local) & cw_can_inject
+        cw_out_valid = cw_forward_valid | cw_inject_valid
+        cw_out_meta = cw_forward_valid.select(cw_in_meta, spb_cw_head_meta)
+        cw_out_data = _select_words(cw_forward_valid, cw_in_data, spb_cw_head_data)
+
+        cc_forward_valid = cc_in_valid & (~sel_ring_cc)
+        cc_can_inject = ~cc_forward_valid
+        cc_inject_valid = spb_cc[nid].out_valid & (~spb_cc_local) & cc_can_inject
+        cc_out_valid = cc_forward_valid | cc_inject_valid
+        cc_out_meta = cc_forward_valid.select(cc_in_meta, spb_cc_head_meta)
+        cc_out_data = _select_words(cc_forward_valid, cc_in_data, spb_cc_head_data)
+
+        req_cw_link_valid[pos].set(cw_out_valid)
+        req_cw_link_meta[pos].set(cw_out_meta)
+        for wi in range(line_words):
+            req_cw_link_data[pos][wi].set(cw_out_data[wi])
+
+        req_cc_link_valid[pos].set(cc_out_valid)
+        req_cc_link_meta[pos].set(cc_out_meta)
+        for wi in range(line_words):
+            req_cc_link_data[pos][wi].set(cc_out_data[wi])
+
+        m.assign(spb_cw_out_ready[nid], sel_spb_cw | cw_inject_valid)
+        m.assign(spb_cc_out_ready[nid], sel_spb_cc | cc_inject_valid)
+
+    # --- Pipe stage regs ---
+    pipe_stage_valid: list[Reg] = []
+    pipe_stage_meta: list[Reg] = []
+    pipe_stage_data: list[list[Reg]] = []
+
+    for p in range(pipe_count):
+        with m.scope(f"pipe{p}_stage"):
+            pipe_stage_valid.append(m.out("v", clk=clk, rst=rst, width=1, init=0, en=1))
+            pipe_stage_meta.append(m.out("m", clk=clk, rst=rst, width=64, init=0, en=1))
+            pipe_stage_data.append(
+                [m.out(f"d_w{wi}", clk=clk, rst=rst, width=64, init=0, en=1) for wi in range(line_words)]
+            )
+
+        pipe_stage_valid[p].set(pipe_req_valid[p])
+        pipe_stage_meta[p].set(pipe_req_meta[p])
+        for wi in range(line_words):
+            pipe_stage_data[p][wi].set(pipe_req_data[p][wi])
+
+    # --- Response inject bundles (per pipe, cw/cc) ---
+    rsp_cw: list[BundleFifo] = []
+    rsp_cc: list[BundleFifo] = []
+    rsp_cw_out_ready: list[Wire] = []
+    rsp_cc_out_ready: list[Wire] = []
+
+    for p in range(pipe_count):
+        st_valid = pipe_stage_valid[p].out()
+        st_meta = pipe_stage_meta[p].out()
+        st_data_words = [r.out() for r in pipe_stage_data[p]]
+
+        st_write = _field(st_meta, lsb=REQ_WRITE_LSB, width=1)
+        st_src = _field(st_meta, lsb=REQ_SRC_LSB, width=node_bits)
+        st_tag = _field(st_meta, lsb=REQ_TAG_LSB, width=tag_bits)
+        st_addr = _field(st_meta, lsb=REQ_ADDR_LSB, width=addr_bits)
+
+        line_idx = st_addr.slice(lsb=offset_bits + pipe_bits, width=index_bits)
+        byte_addr = cat(line_idx, c(0, width=3))
+        depth_bytes = lines_per_pipe * 8
+
+        read_words: list[Wire] = []
+        wvalid = st_valid & st_write
+        wstrb = c(0xFF, width=8)
+
+        for wi in range(line_words):
+            rdata = m.byte_mem(
+                clk=clk,
+                rst=rst,
+                raddr=byte_addr,
+                wvalid=wvalid,
+                waddr=byte_addr,
+                wdata=st_data_words[wi],
+                wstrb=wstrb,
+                depth=depth_bytes,
+                name=f"tmu_p{p}_w{wi}",
+            )
+            read_words.append(rdata)
+
+        rsp_meta = pack_rsp_meta(st_write, c(p, width=node_bits), st_src, st_tag)
+        rsp_words = [st_write.select(st_data_words[wi], read_words[wi]) for wi in range(line_words)]
+
+        rsp_dir = _dir_cw(m, src=p, dst=st_src)
+        in_valid_cw = st_valid & rsp_dir
+        in_valid_cc = st_valid & (~rsp_dir)
+
+        cw_ready = m.named_wire(f"rsp{p}_cw_out_ready", width=1)
+        cc_ready = m.named_wire(f"rsp{p}_cc_out_ready", width=1)
+        rsp_cw_out_ready.append(cw_ready)
+        rsp_cc_out_ready.append(cc_ready)
+
+        rsp_cw.append(
+            _build_bundle_fifo(
+                m,
+                clk=clk,
+                rst=rst,
+                in_valid=in_valid_cw,
+                in_meta=rsp_meta,
+                in_data=rsp_words,
+                out_ready=cw_ready,
+                depth=spb_depth,
+                name=f"rsp{p}_cw",
+            )
+        )
+        rsp_cc.append(
+            _build_bundle_fifo(
+                m,
+                clk=clk,
+                rst=rst,
+                in_valid=in_valid_cc,
+                in_meta=rsp_meta,
+                in_data=rsp_words,
+                out_ready=cc_ready,
+                depth=spb_depth,
+                name=f"rsp{p}_cc",
+            )
+        )
+
+    # --- Response ring traversal + MGB buffers ---
+    for pos in range(NODE_COUNT):
+        nid = RING_ORDER[pos]
+        node_const = c(nid, width=node_bits)
+
+        prev_pos = (pos - 1) % NODE_COUNT
+        next_pos = (pos + 1) % NODE_COUNT
+
+        cw_in_valid = rsp_cw_link_valid[prev_pos].out()
+        cw_in_meta = rsp_cw_link_meta[prev_pos].out()
+        cw_in_data = [r.out() for r in rsp_cw_link_data[prev_pos]]
+
+        cc_in_valid = rsp_cc_link_valid[next_pos].out()
+        cc_in_meta = rsp_cc_link_meta[next_pos].out()
+        cc_in_data = [r.out() for r in rsp_cc_link_data[next_pos]]
+
+        cw_in_dst = _field(cw_in_meta, lsb=RSP_DST_LSB, width=node_bits)
+        cc_in_dst = _field(cc_in_meta, lsb=RSP_DST_LSB, width=node_bits)
+
+        ring_cw_local = cw_in_valid & cw_in_dst.eq(node_const)
+        ring_cc_local = cc_in_valid & cc_in_dst.eq(node_const)
+
+        rsp_cw_head_meta = rsp_cw[nid].out_meta
+        rsp_cc_head_meta = rsp_cc[nid].out_meta
+        rsp_cw_head_data = rsp_cw[nid].out_data
+        rsp_cc_head_data = rsp_cc[nid].out_data
+
+        rsp_cw_dst = _field(rsp_cw_head_meta, lsb=RSP_DST_LSB, width=node_bits)
+        rsp_cc_dst = _field(rsp_cc_head_meta, lsb=RSP_DST_LSB, width=node_bits)
+
+        rsp_cw_local = rsp_cw[nid].out_valid & rsp_cw_dst.eq(node_const)
+        rsp_cc_local = rsp_cc[nid].out_valid & rsp_cc_dst.eq(node_const)
+
+        cw_local_valid = ring_cw_local | rsp_cw_local
+        cc_local_valid = ring_cc_local | rsp_cc_local
+        cw_local_meta = ring_cw_local.select(cw_in_meta, rsp_cw_head_meta)
+        cc_local_meta = ring_cc_local.select(cc_in_meta, rsp_cc_head_meta)
+        cw_local_data = _select_words(ring_cw_local, cw_in_data, rsp_cw_head_data)
+        cc_local_data = _select_words(ring_cc_local, cc_in_data, rsp_cc_head_data)
+
+        # MGB buffers.
+        mgb_cw_ready = m.named_wire(f"mgb{nid}_cw_out_ready", width=1)
+        mgb_cc_ready = m.named_wire(f"mgb{nid}_cc_out_ready", width=1)
+
+        mgb_cw = _build_bundle_fifo(
+            m,
+            clk=clk,
+            rst=rst,
+            in_valid=cw_local_valid,
+            in_meta=cw_local_meta,
+            in_data=cw_local_data,
+            out_ready=mgb_cw_ready,
+            depth=mgb_depth,
+            name=f"mgb{nid}_cw",
+        )
+        mgb_cc = _build_bundle_fifo(
+            m,
+            clk=clk,
+            rst=rst,
+            in_valid=cc_local_valid,
+            in_meta=cc_local_meta,
+            in_data=cc_local_data,
+            out_ready=mgb_cc_ready,
+            depth=mgb_depth,
+            name=f"mgb{nid}_cc",
+        )
+
+        rr = m.out(f"mgb{nid}_rr", clk=clk, rst=rst, width=1, init=0, en=1)
+
+        any_cw = mgb_cw.out_valid
+        any_cc = mgb_cc.out_valid
+        both = any_cw & any_cc
+        pick_cw = (any_cw & (~any_cc)) | (both & (~rr.out()))
+        pick_cc = (any_cc & (~any_cw)) | (both & rr.out())
+
+        resp_ready = nodes[nid].resp_ready
+        resp_fire = (pick_cw | pick_cc) & resp_ready
+
+        m.assign(mgb_cw_ready, pick_cw & resp_ready)
+        m.assign(mgb_cc_ready, pick_cc & resp_ready)
+
+        rr_next = rr.out()
+        rr_next = resp_fire.select(~rr_next, rr_next)
+        rr.set(rr_next)
+
+        resp_meta = pick_cw.select(mgb_cw.out_meta, mgb_cc.out_meta)
+        resp_words = _select_words(pick_cw, mgb_cw.out_data, mgb_cc.out_data)
+
+        m.assign(nodes[nid].resp_valid, resp_fire)
+        m.assign(nodes[nid].resp_tag, _field(resp_meta, lsb=RSP_TAG_LSB, width=tag_bits))
+        m.assign(nodes[nid].resp_is_write, _field(resp_meta, lsb=RSP_WRITE_LSB, width=1))
+        for wi in range(line_words):
+            m.assign(nodes[nid].resp_data_words[wi], resp_words[wi])
+
+        # Forward or inject on response cw lane.
+        cw_forward_valid = cw_in_valid & (~ring_cw_local)
+        cc_forward_valid = cc_in_valid & (~ring_cc_local)
+
+        cw_can_inject = ~cw_forward_valid
+        cc_can_inject = ~cc_forward_valid
+
+        cw_inject_valid = rsp_cw[nid].out_valid & (~rsp_cw_local) & cw_can_inject
+        cc_inject_valid = rsp_cc[nid].out_valid & (~rsp_cc_local) & cc_can_inject
+
+        cw_out_valid = cw_forward_valid | cw_inject_valid
+        cc_out_valid = cc_forward_valid | cc_inject_valid
+
+        cw_out_meta = cw_forward_valid.select(cw_in_meta, rsp_cw_head_meta)
+        cc_out_meta = cc_forward_valid.select(cc_in_meta, rsp_cc_head_meta)
+        cw_out_data = _select_words(cw_forward_valid, cw_in_data, rsp_cw_head_data)
+        cc_out_data = _select_words(cc_forward_valid, cc_in_data, rsp_cc_head_data)
+
+        rsp_cw_link_valid[pos].set(cw_out_valid)
+        rsp_cw_link_meta[pos].set(cw_out_meta)
+        for wi in range(line_words):
+            rsp_cw_link_data[pos][wi].set(cw_out_data[wi])
+
+        rsp_cc_link_valid[pos].set(cc_out_valid)
+        rsp_cc_link_meta[pos].set(cc_out_meta)
+        for wi in range(line_words):
+            rsp_cc_link_data[pos][wi].set(cc_out_data[wi])
+
+        rsp_cw_local_pop = rsp_cw_local & (~ring_cw_local) & mgb_cw.in_ready
+        rsp_cc_local_pop = rsp_cc_local & (~ring_cc_local) & mgb_cc.in_ready
+        m.assign(rsp_cw_out_ready[nid], rsp_cw_local_pop | cw_inject_valid)
+        m.assign(rsp_cc_out_ready[nid], rsp_cc_local_pop | cc_inject_valid)
+
+    # --- Debug ring metadata outputs (for visualization) ---
+    for pos in range(NODE_COUNT):
+        nid = RING_ORDER[pos]
+        req_meta = req_cw_link_meta[pos].out().slice(lsb=0, width=REQ_ADDR_LSB + addr_bits)
+        req_meta_cc = req_cc_link_meta[pos].out().slice(lsb=0, width=REQ_ADDR_LSB + addr_bits)
+        rsp_meta = rsp_cw_link_meta[pos].out().slice(lsb=0, width=RSP_TAG_LSB + tag_bits)
+        rsp_meta_cc = rsp_cc_link_meta[pos].out().slice(lsb=0, width=RSP_TAG_LSB + tag_bits)
+        m.output(f"dbg_req_cw_v{nid}", req_cw_link_valid[pos].out())
+        m.output(f"dbg_req_cc_v{nid}", req_cc_link_valid[pos].out())
+        m.output(f"dbg_req_cw_meta{nid}", req_meta)
+        m.output(f"dbg_req_cc_meta{nid}", req_meta_cc)
+        m.output(f"dbg_rsp_cw_v{nid}", rsp_cw_link_valid[pos].out())
+        m.output(f"dbg_rsp_cc_v{nid}", rsp_cc_link_valid[pos].out())
+        m.output(f"dbg_rsp_cw_meta{nid}", rsp_meta)
+        m.output(f"dbg_rsp_cc_meta{nid}", rsp_meta_cc)
+
+    for i, node in enumerate(nodes):
+        m.output(f"n{i}_req_ready", node.req_ready)
+        m.output(f"n{i}_resp_valid", node.resp_valid)
+        m.output(f"n{i}_resp_tag", node.resp_tag)
+        for wi in range(line_words):
+            m.output(f"n{i}_resp_data_w{wi}", node.resp_data_words[wi])
+        m.output(f"n{i}_resp_is_write", node.resp_is_write)
+
+
+build.__pycircuit_name__ = "janus_tmu_pyc"

--- a/janus/tb/tb_janus_tmu_pyc.cpp
+++ b/janus/tb/tb_janus_tmu_pyc.cpp
@@ -1,0 +1,286 @@
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+
+#include <pyc/cpp/pyc_konata.hpp>
+#include <pyc/cpp/pyc_tb.hpp>
+
+#include "janus_tmu_pyc_gen.hpp"
+
+using pyc::cpp::Testbench;
+using pyc::cpp::Wire;
+
+namespace {
+
+constexpr int kNodes = 8;
+constexpr int kAddrBits = 20;
+constexpr int kTagBits = 8;
+constexpr int kWords = 32;
+
+using DataWord = Wire<64>;
+using DataLine = std::array<DataWord, kWords>;
+
+struct NodePorts {
+  Wire<1> *req_valid = nullptr;
+  Wire<1> *req_write = nullptr;
+  Wire<kAddrBits> *req_addr = nullptr;
+  Wire<kTagBits> *req_tag = nullptr;
+  std::array<DataWord *, kWords> req_data{};
+  Wire<1> *req_ready = nullptr;
+  Wire<1> *resp_ready = nullptr;
+  Wire<1> *resp_valid = nullptr;
+  Wire<kTagBits> *resp_tag = nullptr;
+  std::array<DataWord *, kWords> resp_data{};
+  Wire<1> *resp_is_write = nullptr;
+};
+
+static bool envFlag(const char *name) {
+  const char *v = std::getenv(name);
+  if (!v)
+    return false;
+  return !(v[0] == '0' && v[1] == '\0');
+}
+
+static std::uint32_t makeAddr(std::uint32_t index, std::uint32_t pipe, std::uint32_t offset = 0) {
+  return (index << 11) | (pipe << 8) | (offset & 0xFFu);
+}
+
+static DataLine makeData(std::uint32_t seed) {
+  DataLine out{};
+  for (unsigned i = 0; i < kWords; i++) {
+    std::uint64_t word = (static_cast<std::uint64_t>(seed) << 32) | i;
+    out[i] = DataWord(word);
+  }
+  return out;
+}
+
+static void zeroReq(NodePorts &n) {
+  *n.req_valid = Wire<1>(0);
+  *n.req_write = Wire<1>(0);
+  *n.req_addr = Wire<kAddrBits>(0);
+  *n.req_tag = Wire<kTagBits>(0);
+  for (auto *w : n.req_data)
+    *w = DataWord(0);
+}
+
+static void setRespReady(NodePorts &n, bool ready) { *n.resp_ready = Wire<1>(ready ? 1u : 0u); }
+
+static void sendReq(Testbench<pyc::gen::janus_tmu_pyc> &tb,
+                    NodePorts &n,
+                    std::uint64_t &cycle,
+                    int node_id,
+                    bool write,
+                    std::uint32_t addr,
+                    std::uint8_t tag,
+                    const DataLine &data,
+                    std::ofstream &trace) {
+  *n.req_write = Wire<1>(write ? 1u : 0u);
+  *n.req_addr = Wire<kAddrBits>(addr);
+  *n.req_tag = Wire<kTagBits>(tag);
+  for (unsigned i = 0; i < kWords; i++)
+    *n.req_data[i] = data[i];
+  *n.req_valid = Wire<1>(1);
+  while (true) {
+    tb.runCycles(1);
+    cycle++;
+    if (n.req_ready->toBool()) {
+      trace << cycle << ",accept"
+            << "," << node_id << "," << unsigned(tag) << "," << (write ? 1 : 0) << ",0x" << std::hex << addr
+            << std::dec << ",0x"
+            << std::hex << data[0].value() << std::dec << "\n";
+      break;
+    }
+  }
+  *n.req_valid = Wire<1>(0);
+}
+
+static void waitResp(Testbench<pyc::gen::janus_tmu_pyc> &tb,
+                     NodePorts &n,
+                     std::uint64_t &cycle,
+                     int node_id,
+                     std::uint8_t tag,
+                     bool expect_write,
+                     const DataLine &expect_data,
+                     std::ofstream &trace) {
+  for (std::uint64_t i = 0; i < 2000; i++) {
+    tb.runCycles(1);
+    cycle++;
+    if (!n.resp_valid->toBool())
+      continue;
+    if (n.resp_tag->value() != tag) {
+      std::cerr << "FAIL: tag mismatch. got=" << std::hex << n.resp_tag->value() << " exp=" << unsigned(tag) << std::dec
+                << "\n";
+      std::exit(1);
+    }
+    if (n.resp_is_write->toBool() != expect_write) {
+      std::cerr << "FAIL: resp_is_write mismatch\n";
+      std::exit(1);
+    }
+    for (unsigned i = 0; i < kWords; i++) {
+      if (n.resp_data[i]->value() != expect_data[i].value()) {
+        std::cerr << "FAIL: resp_data mismatch\n";
+        std::exit(1);
+      }
+    }
+    trace << cycle << ",resp"
+          << "," << node_id << "," << unsigned(tag) << "," << (expect_write ? 1 : 0) << ",0x" << std::hex
+          << n.resp_data[0]->value()
+          << std::dec << "\n";
+    return;
+  }
+  std::cerr << "FAIL: timeout waiting for response tag=0x" << std::hex << unsigned(tag) << std::dec << "\n";
+  std::exit(1);
+}
+
+} // namespace
+
+int main() {
+  pyc::gen::janus_tmu_pyc dut{};
+  Testbench<pyc::gen::janus_tmu_pyc> tb(dut);
+
+  const bool trace_log = envFlag("PYC_TRACE");
+  const bool trace_vcd = envFlag("PYC_VCD");
+
+  std::filesystem::path out_dir{};
+  if (trace_log || trace_vcd) {
+    const char *trace_dir_env = std::getenv("PYC_TRACE_DIR");
+    out_dir = trace_dir_env ? std::filesystem::path(trace_dir_env) : std::filesystem::path("janus/generated/janus_tmu_pyc");
+    std::filesystem::create_directories(out_dir);
+  }
+
+  if (trace_log) {
+    tb.enableLog((out_dir / "tb_janus_tmu_pyc_cpp.log").string());
+  }
+
+  if (trace_vcd) {
+    tb.enableVcd((out_dir / "tb_janus_tmu_pyc_cpp.vcd").string(), /*top=*/"tb_janus_tmu_pyc_cpp");
+    tb.vcdTrace(dut.clk, "clk");
+    tb.vcdTrace(dut.rst, "rst");
+    tb.vcdTrace(dut.n0_req_valid, "n0_req_valid");
+    tb.vcdTrace(dut.n0_req_ready, "n0_req_ready");
+    tb.vcdTrace(dut.n0_resp_valid, "n0_resp_valid");
+    tb.vcdTrace(dut.n0_resp_is_write, "n0_resp_is_write");
+    tb.vcdTrace(dut.n0_resp_tag, "n0_resp_tag");
+    tb.vcdTrace(dut.n0_req_data_w0, "n0_req_data_w0");
+    tb.vcdTrace(dut.n0_resp_data_w0, "n0_resp_data_w0");
+    tb.vcdTrace(dut.dbg_req_cw_v0, "dbg_req_cw_v0");
+    tb.vcdTrace(dut.dbg_req_cc_v0, "dbg_req_cc_v0");
+    tb.vcdTrace(dut.dbg_rsp_cw_v0, "dbg_rsp_cw_v0");
+    tb.vcdTrace(dut.dbg_rsp_cc_v0, "dbg_rsp_cc_v0");
+    tb.vcdTrace(dut.dbg_req_cw_v1, "dbg_req_cw_v1");
+    tb.vcdTrace(dut.dbg_req_cc_v1, "dbg_req_cc_v1");
+    tb.vcdTrace(dut.dbg_rsp_cw_v1, "dbg_rsp_cw_v1");
+    tb.vcdTrace(dut.dbg_rsp_cc_v1, "dbg_rsp_cc_v1");
+    tb.vcdTrace(dut.dbg_req_cw_v2, "dbg_req_cw_v2");
+    tb.vcdTrace(dut.dbg_req_cc_v2, "dbg_req_cc_v2");
+    tb.vcdTrace(dut.dbg_rsp_cw_v2, "dbg_rsp_cw_v2");
+    tb.vcdTrace(dut.dbg_rsp_cc_v2, "dbg_rsp_cc_v2");
+    tb.vcdTrace(dut.dbg_req_cw_v3, "dbg_req_cw_v3");
+    tb.vcdTrace(dut.dbg_req_cc_v3, "dbg_req_cc_v3");
+    tb.vcdTrace(dut.dbg_rsp_cw_v3, "dbg_rsp_cw_v3");
+    tb.vcdTrace(dut.dbg_rsp_cc_v3, "dbg_rsp_cc_v3");
+    tb.vcdTrace(dut.dbg_req_cw_v4, "dbg_req_cw_v4");
+    tb.vcdTrace(dut.dbg_req_cc_v4, "dbg_req_cc_v4");
+    tb.vcdTrace(dut.dbg_rsp_cw_v4, "dbg_rsp_cw_v4");
+    tb.vcdTrace(dut.dbg_rsp_cc_v4, "dbg_rsp_cc_v4");
+    tb.vcdTrace(dut.dbg_req_cw_v5, "dbg_req_cw_v5");
+    tb.vcdTrace(dut.dbg_req_cc_v5, "dbg_req_cc_v5");
+    tb.vcdTrace(dut.dbg_rsp_cw_v5, "dbg_rsp_cw_v5");
+    tb.vcdTrace(dut.dbg_rsp_cc_v5, "dbg_rsp_cc_v5");
+    tb.vcdTrace(dut.dbg_req_cw_v6, "dbg_req_cw_v6");
+    tb.vcdTrace(dut.dbg_req_cc_v6, "dbg_req_cc_v6");
+    tb.vcdTrace(dut.dbg_rsp_cw_v6, "dbg_rsp_cw_v6");
+    tb.vcdTrace(dut.dbg_rsp_cc_v6, "dbg_rsp_cc_v6");
+    tb.vcdTrace(dut.dbg_req_cw_v7, "dbg_req_cw_v7");
+    tb.vcdTrace(dut.dbg_req_cc_v7, "dbg_req_cc_v7");
+    tb.vcdTrace(dut.dbg_rsp_cw_v7, "dbg_rsp_cw_v7");
+    tb.vcdTrace(dut.dbg_rsp_cc_v7, "dbg_rsp_cc_v7");
+  }
+
+  tb.addClock(dut.clk, /*halfPeriodSteps=*/1);
+  tb.reset(dut.rst, /*cyclesAsserted=*/2, /*cyclesDeasserted=*/1);
+
+  std::ofstream trace;
+  if (trace_log) {
+    trace.open(out_dir / "tmu_trace.csv", std::ios::out | std::ios::trunc);
+    trace << "cycle,event,node,tag,write,addr_or_word0,data_word0\n";
+  }
+
+  std::array<NodePorts, kNodes> nodes = {{
+      {&dut.n0_req_valid, &dut.n0_req_write, &dut.n0_req_addr, &dut.n0_req_tag,
+       {&dut.n0_req_data_w0, &dut.n0_req_data_w1, &dut.n0_req_data_w2, &dut.n0_req_data_w3, &dut.n0_req_data_w4, &dut.n0_req_data_w5, &dut.n0_req_data_w6, &dut.n0_req_data_w7, &dut.n0_req_data_w8, &dut.n0_req_data_w9, &dut.n0_req_data_w10, &dut.n0_req_data_w11, &dut.n0_req_data_w12, &dut.n0_req_data_w13, &dut.n0_req_data_w14, &dut.n0_req_data_w15, &dut.n0_req_data_w16, &dut.n0_req_data_w17, &dut.n0_req_data_w18, &dut.n0_req_data_w19, &dut.n0_req_data_w20, &dut.n0_req_data_w21, &dut.n0_req_data_w22, &dut.n0_req_data_w23, &dut.n0_req_data_w24, &dut.n0_req_data_w25, &dut.n0_req_data_w26, &dut.n0_req_data_w27, &dut.n0_req_data_w28, &dut.n0_req_data_w29, &dut.n0_req_data_w30, &dut.n0_req_data_w31}, &dut.n0_req_ready, &dut.n0_resp_ready, &dut.n0_resp_valid, &dut.n0_resp_tag,
+       {&dut.n0_resp_data_w0, &dut.n0_resp_data_w1, &dut.n0_resp_data_w2, &dut.n0_resp_data_w3, &dut.n0_resp_data_w4, &dut.n0_resp_data_w5, &dut.n0_resp_data_w6, &dut.n0_resp_data_w7, &dut.n0_resp_data_w8, &dut.n0_resp_data_w9, &dut.n0_resp_data_w10, &dut.n0_resp_data_w11, &dut.n0_resp_data_w12, &dut.n0_resp_data_w13, &dut.n0_resp_data_w14, &dut.n0_resp_data_w15, &dut.n0_resp_data_w16, &dut.n0_resp_data_w17, &dut.n0_resp_data_w18, &dut.n0_resp_data_w19, &dut.n0_resp_data_w20, &dut.n0_resp_data_w21, &dut.n0_resp_data_w22, &dut.n0_resp_data_w23, &dut.n0_resp_data_w24, &dut.n0_resp_data_w25, &dut.n0_resp_data_w26, &dut.n0_resp_data_w27, &dut.n0_resp_data_w28, &dut.n0_resp_data_w29, &dut.n0_resp_data_w30, &dut.n0_resp_data_w31}, &dut.n0_resp_is_write},
+      {&dut.n1_req_valid, &dut.n1_req_write, &dut.n1_req_addr, &dut.n1_req_tag,
+       {&dut.n1_req_data_w0, &dut.n1_req_data_w1, &dut.n1_req_data_w2, &dut.n1_req_data_w3, &dut.n1_req_data_w4, &dut.n1_req_data_w5, &dut.n1_req_data_w6, &dut.n1_req_data_w7, &dut.n1_req_data_w8, &dut.n1_req_data_w9, &dut.n1_req_data_w10, &dut.n1_req_data_w11, &dut.n1_req_data_w12, &dut.n1_req_data_w13, &dut.n1_req_data_w14, &dut.n1_req_data_w15, &dut.n1_req_data_w16, &dut.n1_req_data_w17, &dut.n1_req_data_w18, &dut.n1_req_data_w19, &dut.n1_req_data_w20, &dut.n1_req_data_w21, &dut.n1_req_data_w22, &dut.n1_req_data_w23, &dut.n1_req_data_w24, &dut.n1_req_data_w25, &dut.n1_req_data_w26, &dut.n1_req_data_w27, &dut.n1_req_data_w28, &dut.n1_req_data_w29, &dut.n1_req_data_w30, &dut.n1_req_data_w31}, &dut.n1_req_ready, &dut.n1_resp_ready, &dut.n1_resp_valid, &dut.n1_resp_tag,
+       {&dut.n1_resp_data_w0, &dut.n1_resp_data_w1, &dut.n1_resp_data_w2, &dut.n1_resp_data_w3, &dut.n1_resp_data_w4, &dut.n1_resp_data_w5, &dut.n1_resp_data_w6, &dut.n1_resp_data_w7, &dut.n1_resp_data_w8, &dut.n1_resp_data_w9, &dut.n1_resp_data_w10, &dut.n1_resp_data_w11, &dut.n1_resp_data_w12, &dut.n1_resp_data_w13, &dut.n1_resp_data_w14, &dut.n1_resp_data_w15, &dut.n1_resp_data_w16, &dut.n1_resp_data_w17, &dut.n1_resp_data_w18, &dut.n1_resp_data_w19, &dut.n1_resp_data_w20, &dut.n1_resp_data_w21, &dut.n1_resp_data_w22, &dut.n1_resp_data_w23, &dut.n1_resp_data_w24, &dut.n1_resp_data_w25, &dut.n1_resp_data_w26, &dut.n1_resp_data_w27, &dut.n1_resp_data_w28, &dut.n1_resp_data_w29, &dut.n1_resp_data_w30, &dut.n1_resp_data_w31}, &dut.n1_resp_is_write},
+      {&dut.n2_req_valid, &dut.n2_req_write, &dut.n2_req_addr, &dut.n2_req_tag,
+       {&dut.n2_req_data_w0, &dut.n2_req_data_w1, &dut.n2_req_data_w2, &dut.n2_req_data_w3, &dut.n2_req_data_w4, &dut.n2_req_data_w5, &dut.n2_req_data_w6, &dut.n2_req_data_w7, &dut.n2_req_data_w8, &dut.n2_req_data_w9, &dut.n2_req_data_w10, &dut.n2_req_data_w11, &dut.n2_req_data_w12, &dut.n2_req_data_w13, &dut.n2_req_data_w14, &dut.n2_req_data_w15, &dut.n2_req_data_w16, &dut.n2_req_data_w17, &dut.n2_req_data_w18, &dut.n2_req_data_w19, &dut.n2_req_data_w20, &dut.n2_req_data_w21, &dut.n2_req_data_w22, &dut.n2_req_data_w23, &dut.n2_req_data_w24, &dut.n2_req_data_w25, &dut.n2_req_data_w26, &dut.n2_req_data_w27, &dut.n2_req_data_w28, &dut.n2_req_data_w29, &dut.n2_req_data_w30, &dut.n2_req_data_w31}, &dut.n2_req_ready, &dut.n2_resp_ready, &dut.n2_resp_valid, &dut.n2_resp_tag,
+       {&dut.n2_resp_data_w0, &dut.n2_resp_data_w1, &dut.n2_resp_data_w2, &dut.n2_resp_data_w3, &dut.n2_resp_data_w4, &dut.n2_resp_data_w5, &dut.n2_resp_data_w6, &dut.n2_resp_data_w7, &dut.n2_resp_data_w8, &dut.n2_resp_data_w9, &dut.n2_resp_data_w10, &dut.n2_resp_data_w11, &dut.n2_resp_data_w12, &dut.n2_resp_data_w13, &dut.n2_resp_data_w14, &dut.n2_resp_data_w15, &dut.n2_resp_data_w16, &dut.n2_resp_data_w17, &dut.n2_resp_data_w18, &dut.n2_resp_data_w19, &dut.n2_resp_data_w20, &dut.n2_resp_data_w21, &dut.n2_resp_data_w22, &dut.n2_resp_data_w23, &dut.n2_resp_data_w24, &dut.n2_resp_data_w25, &dut.n2_resp_data_w26, &dut.n2_resp_data_w27, &dut.n2_resp_data_w28, &dut.n2_resp_data_w29, &dut.n2_resp_data_w30, &dut.n2_resp_data_w31}, &dut.n2_resp_is_write},
+      {&dut.n3_req_valid, &dut.n3_req_write, &dut.n3_req_addr, &dut.n3_req_tag,
+       {&dut.n3_req_data_w0, &dut.n3_req_data_w1, &dut.n3_req_data_w2, &dut.n3_req_data_w3, &dut.n3_req_data_w4, &dut.n3_req_data_w5, &dut.n3_req_data_w6, &dut.n3_req_data_w7, &dut.n3_req_data_w8, &dut.n3_req_data_w9, &dut.n3_req_data_w10, &dut.n3_req_data_w11, &dut.n3_req_data_w12, &dut.n3_req_data_w13, &dut.n3_req_data_w14, &dut.n3_req_data_w15, &dut.n3_req_data_w16, &dut.n3_req_data_w17, &dut.n3_req_data_w18, &dut.n3_req_data_w19, &dut.n3_req_data_w20, &dut.n3_req_data_w21, &dut.n3_req_data_w22, &dut.n3_req_data_w23, &dut.n3_req_data_w24, &dut.n3_req_data_w25, &dut.n3_req_data_w26, &dut.n3_req_data_w27, &dut.n3_req_data_w28, &dut.n3_req_data_w29, &dut.n3_req_data_w30, &dut.n3_req_data_w31}, &dut.n3_req_ready, &dut.n3_resp_ready, &dut.n3_resp_valid, &dut.n3_resp_tag,
+       {&dut.n3_resp_data_w0, &dut.n3_resp_data_w1, &dut.n3_resp_data_w2, &dut.n3_resp_data_w3, &dut.n3_resp_data_w4, &dut.n3_resp_data_w5, &dut.n3_resp_data_w6, &dut.n3_resp_data_w7, &dut.n3_resp_data_w8, &dut.n3_resp_data_w9, &dut.n3_resp_data_w10, &dut.n3_resp_data_w11, &dut.n3_resp_data_w12, &dut.n3_resp_data_w13, &dut.n3_resp_data_w14, &dut.n3_resp_data_w15, &dut.n3_resp_data_w16, &dut.n3_resp_data_w17, &dut.n3_resp_data_w18, &dut.n3_resp_data_w19, &dut.n3_resp_data_w20, &dut.n3_resp_data_w21, &dut.n3_resp_data_w22, &dut.n3_resp_data_w23, &dut.n3_resp_data_w24, &dut.n3_resp_data_w25, &dut.n3_resp_data_w26, &dut.n3_resp_data_w27, &dut.n3_resp_data_w28, &dut.n3_resp_data_w29, &dut.n3_resp_data_w30, &dut.n3_resp_data_w31}, &dut.n3_resp_is_write},
+      {&dut.n4_req_valid, &dut.n4_req_write, &dut.n4_req_addr, &dut.n4_req_tag,
+       {&dut.n4_req_data_w0, &dut.n4_req_data_w1, &dut.n4_req_data_w2, &dut.n4_req_data_w3, &dut.n4_req_data_w4, &dut.n4_req_data_w5, &dut.n4_req_data_w6, &dut.n4_req_data_w7, &dut.n4_req_data_w8, &dut.n4_req_data_w9, &dut.n4_req_data_w10, &dut.n4_req_data_w11, &dut.n4_req_data_w12, &dut.n4_req_data_w13, &dut.n4_req_data_w14, &dut.n4_req_data_w15, &dut.n4_req_data_w16, &dut.n4_req_data_w17, &dut.n4_req_data_w18, &dut.n4_req_data_w19, &dut.n4_req_data_w20, &dut.n4_req_data_w21, &dut.n4_req_data_w22, &dut.n4_req_data_w23, &dut.n4_req_data_w24, &dut.n4_req_data_w25, &dut.n4_req_data_w26, &dut.n4_req_data_w27, &dut.n4_req_data_w28, &dut.n4_req_data_w29, &dut.n4_req_data_w30, &dut.n4_req_data_w31}, &dut.n4_req_ready, &dut.n4_resp_ready, &dut.n4_resp_valid, &dut.n4_resp_tag,
+       {&dut.n4_resp_data_w0, &dut.n4_resp_data_w1, &dut.n4_resp_data_w2, &dut.n4_resp_data_w3, &dut.n4_resp_data_w4, &dut.n4_resp_data_w5, &dut.n4_resp_data_w6, &dut.n4_resp_data_w7, &dut.n4_resp_data_w8, &dut.n4_resp_data_w9, &dut.n4_resp_data_w10, &dut.n4_resp_data_w11, &dut.n4_resp_data_w12, &dut.n4_resp_data_w13, &dut.n4_resp_data_w14, &dut.n4_resp_data_w15, &dut.n4_resp_data_w16, &dut.n4_resp_data_w17, &dut.n4_resp_data_w18, &dut.n4_resp_data_w19, &dut.n4_resp_data_w20, &dut.n4_resp_data_w21, &dut.n4_resp_data_w22, &dut.n4_resp_data_w23, &dut.n4_resp_data_w24, &dut.n4_resp_data_w25, &dut.n4_resp_data_w26, &dut.n4_resp_data_w27, &dut.n4_resp_data_w28, &dut.n4_resp_data_w29, &dut.n4_resp_data_w30, &dut.n4_resp_data_w31}, &dut.n4_resp_is_write},
+      {&dut.n5_req_valid, &dut.n5_req_write, &dut.n5_req_addr, &dut.n5_req_tag,
+       {&dut.n5_req_data_w0, &dut.n5_req_data_w1, &dut.n5_req_data_w2, &dut.n5_req_data_w3, &dut.n5_req_data_w4, &dut.n5_req_data_w5, &dut.n5_req_data_w6, &dut.n5_req_data_w7, &dut.n5_req_data_w8, &dut.n5_req_data_w9, &dut.n5_req_data_w10, &dut.n5_req_data_w11, &dut.n5_req_data_w12, &dut.n5_req_data_w13, &dut.n5_req_data_w14, &dut.n5_req_data_w15, &dut.n5_req_data_w16, &dut.n5_req_data_w17, &dut.n5_req_data_w18, &dut.n5_req_data_w19, &dut.n5_req_data_w20, &dut.n5_req_data_w21, &dut.n5_req_data_w22, &dut.n5_req_data_w23, &dut.n5_req_data_w24, &dut.n5_req_data_w25, &dut.n5_req_data_w26, &dut.n5_req_data_w27, &dut.n5_req_data_w28, &dut.n5_req_data_w29, &dut.n5_req_data_w30, &dut.n5_req_data_w31}, &dut.n5_req_ready, &dut.n5_resp_ready, &dut.n5_resp_valid, &dut.n5_resp_tag,
+       {&dut.n5_resp_data_w0, &dut.n5_resp_data_w1, &dut.n5_resp_data_w2, &dut.n5_resp_data_w3, &dut.n5_resp_data_w4, &dut.n5_resp_data_w5, &dut.n5_resp_data_w6, &dut.n5_resp_data_w7, &dut.n5_resp_data_w8, &dut.n5_resp_data_w9, &dut.n5_resp_data_w10, &dut.n5_resp_data_w11, &dut.n5_resp_data_w12, &dut.n5_resp_data_w13, &dut.n5_resp_data_w14, &dut.n5_resp_data_w15, &dut.n5_resp_data_w16, &dut.n5_resp_data_w17, &dut.n5_resp_data_w18, &dut.n5_resp_data_w19, &dut.n5_resp_data_w20, &dut.n5_resp_data_w21, &dut.n5_resp_data_w22, &dut.n5_resp_data_w23, &dut.n5_resp_data_w24, &dut.n5_resp_data_w25, &dut.n5_resp_data_w26, &dut.n5_resp_data_w27, &dut.n5_resp_data_w28, &dut.n5_resp_data_w29, &dut.n5_resp_data_w30, &dut.n5_resp_data_w31}, &dut.n5_resp_is_write},
+      {&dut.n6_req_valid, &dut.n6_req_write, &dut.n6_req_addr, &dut.n6_req_tag,
+       {&dut.n6_req_data_w0, &dut.n6_req_data_w1, &dut.n6_req_data_w2, &dut.n6_req_data_w3, &dut.n6_req_data_w4, &dut.n6_req_data_w5, &dut.n6_req_data_w6, &dut.n6_req_data_w7, &dut.n6_req_data_w8, &dut.n6_req_data_w9, &dut.n6_req_data_w10, &dut.n6_req_data_w11, &dut.n6_req_data_w12, &dut.n6_req_data_w13, &dut.n6_req_data_w14, &dut.n6_req_data_w15, &dut.n6_req_data_w16, &dut.n6_req_data_w17, &dut.n6_req_data_w18, &dut.n6_req_data_w19, &dut.n6_req_data_w20, &dut.n6_req_data_w21, &dut.n6_req_data_w22, &dut.n6_req_data_w23, &dut.n6_req_data_w24, &dut.n6_req_data_w25, &dut.n6_req_data_w26, &dut.n6_req_data_w27, &dut.n6_req_data_w28, &dut.n6_req_data_w29, &dut.n6_req_data_w30, &dut.n6_req_data_w31}, &dut.n6_req_ready, &dut.n6_resp_ready, &dut.n6_resp_valid, &dut.n6_resp_tag,
+       {&dut.n6_resp_data_w0, &dut.n6_resp_data_w1, &dut.n6_resp_data_w2, &dut.n6_resp_data_w3, &dut.n6_resp_data_w4, &dut.n6_resp_data_w5, &dut.n6_resp_data_w6, &dut.n6_resp_data_w7, &dut.n6_resp_data_w8, &dut.n6_resp_data_w9, &dut.n6_resp_data_w10, &dut.n6_resp_data_w11, &dut.n6_resp_data_w12, &dut.n6_resp_data_w13, &dut.n6_resp_data_w14, &dut.n6_resp_data_w15, &dut.n6_resp_data_w16, &dut.n6_resp_data_w17, &dut.n6_resp_data_w18, &dut.n6_resp_data_w19, &dut.n6_resp_data_w20, &dut.n6_resp_data_w21, &dut.n6_resp_data_w22, &dut.n6_resp_data_w23, &dut.n6_resp_data_w24, &dut.n6_resp_data_w25, &dut.n6_resp_data_w26, &dut.n6_resp_data_w27, &dut.n6_resp_data_w28, &dut.n6_resp_data_w29, &dut.n6_resp_data_w30, &dut.n6_resp_data_w31}, &dut.n6_resp_is_write},
+      {&dut.n7_req_valid, &dut.n7_req_write, &dut.n7_req_addr, &dut.n7_req_tag,
+       {&dut.n7_req_data_w0, &dut.n7_req_data_w1, &dut.n7_req_data_w2, &dut.n7_req_data_w3, &dut.n7_req_data_w4, &dut.n7_req_data_w5, &dut.n7_req_data_w6, &dut.n7_req_data_w7, &dut.n7_req_data_w8, &dut.n7_req_data_w9, &dut.n7_req_data_w10, &dut.n7_req_data_w11, &dut.n7_req_data_w12, &dut.n7_req_data_w13, &dut.n7_req_data_w14, &dut.n7_req_data_w15, &dut.n7_req_data_w16, &dut.n7_req_data_w17, &dut.n7_req_data_w18, &dut.n7_req_data_w19, &dut.n7_req_data_w20, &dut.n7_req_data_w21, &dut.n7_req_data_w22, &dut.n7_req_data_w23, &dut.n7_req_data_w24, &dut.n7_req_data_w25, &dut.n7_req_data_w26, &dut.n7_req_data_w27, &dut.n7_req_data_w28, &dut.n7_req_data_w29, &dut.n7_req_data_w30, &dut.n7_req_data_w31}, &dut.n7_req_ready, &dut.n7_resp_ready, &dut.n7_resp_valid, &dut.n7_resp_tag,
+       {&dut.n7_resp_data_w0, &dut.n7_resp_data_w1, &dut.n7_resp_data_w2, &dut.n7_resp_data_w3, &dut.n7_resp_data_w4, &dut.n7_resp_data_w5, &dut.n7_resp_data_w6, &dut.n7_resp_data_w7, &dut.n7_resp_data_w8, &dut.n7_resp_data_w9, &dut.n7_resp_data_w10, &dut.n7_resp_data_w11, &dut.n7_resp_data_w12, &dut.n7_resp_data_w13, &dut.n7_resp_data_w14, &dut.n7_resp_data_w15, &dut.n7_resp_data_w16, &dut.n7_resp_data_w17, &dut.n7_resp_data_w18, &dut.n7_resp_data_w19, &dut.n7_resp_data_w20, &dut.n7_resp_data_w21, &dut.n7_resp_data_w22, &dut.n7_resp_data_w23, &dut.n7_resp_data_w24, &dut.n7_resp_data_w25, &dut.n7_resp_data_w26, &dut.n7_resp_data_w27, &dut.n7_resp_data_w28, &dut.n7_resp_data_w29, &dut.n7_resp_data_w30, &dut.n7_resp_data_w31}, &dut.n7_resp_is_write},
+  }};
+
+  for (auto &n : nodes) {
+    zeroReq(n);
+    setRespReady(n, true);
+  }
+
+  std::uint64_t cycle = 0;
+
+  for (int n = 0; n < kNodes; n++) {
+    const auto addr = makeAddr(static_cast<std::uint32_t>(n), static_cast<std::uint32_t>(n));
+    const auto data = makeData(static_cast<std::uint32_t>(n + 1));
+    const std::uint8_t tag_w = static_cast<std::uint8_t>(n);
+    const std::uint8_t tag_r = static_cast<std::uint8_t>(0x80 | n);
+
+    sendReq(tb, nodes[n], cycle, n, true, addr, tag_w, data, trace);
+    waitResp(tb, nodes[n], cycle, n, tag_w, true, data, trace);
+
+    sendReq(tb, nodes[n], cycle, n, false, addr, tag_r, DataLine{}, trace);
+    waitResp(tb, nodes[n], cycle, n, tag_r, false, data, trace);
+  }
+
+  // Cross-node: node0 writes to pipe2, then reads it back.
+  {
+    const auto addr = makeAddr(5, 2);
+    const auto data = makeData(0xAA);
+    sendReq(tb, nodes[0], cycle, 0, true, addr, 0x55, data, trace);
+    waitResp(tb, nodes[0], cycle, 0, 0x55, true, data, trace);
+    sendReq(tb, nodes[0], cycle, 0, false, addr, 0x56, DataLine{}, trace);
+    waitResp(tb, nodes[0], cycle, 0, 0x56, false, data, trace);
+  }
+
+  // Ring traffic: each node accesses a non-local pipe to exercise ring flow.
+  for (int n = 0; n < kNodes; n++) {
+    const int dst_pipe = (n + 2) % kNodes;
+    const auto addr = makeAddr(16 + n, static_cast<std::uint32_t>(dst_pipe));
+    const auto data = makeData(0x100 + n);
+    const std::uint8_t tag_w = static_cast<std::uint8_t>(0x20 + n);
+    const std::uint8_t tag_r = static_cast<std::uint8_t>(0xA0 + n);
+
+    sendReq(tb, nodes[n], cycle, n, true, addr, tag_w, data, trace);
+    waitResp(tb, nodes[n], cycle, n, tag_w, true, data, trace);
+    sendReq(tb, nodes[n], cycle, n, false, addr, tag_r, DataLine{}, trace);
+    waitResp(tb, nodes[n], cycle, n, tag_r, false, data, trace);
+  }
+
+  std::cout << "PASS: TMU tests\n";
+  return 0;
+}

--- a/janus/tb/tb_janus_tmu_pyc.sv
+++ b/janus/tb/tb_janus_tmu_pyc.sv
@@ -1,0 +1,744 @@
+module tb_janus_tmu_pyc;
+  logic clk;
+  logic rst;
+
+  logic req_valid [0:7];
+  logic req_write [0:7];
+  logic [19:0] req_addr [0:7];
+  logic [7:0] req_tag [0:7];
+  logic [63:0] req_data [0:7][0:31];
+  logic req_ready [0:7];
+
+  logic resp_ready [0:7];
+  logic resp_valid [0:7];
+  logic [7:0] resp_tag [0:7];
+  logic [63:0] resp_data [0:7][0:31];
+  logic resp_is_write [0:7];
+
+  logic [63:0] line_data [0:31];
+  logic [63:0] line_zero [0:31];
+
+  janus_tmu_pyc dut (
+      .clk(clk),
+      .rst(rst),
+      .n0_req_valid(req_valid[0]),
+      .n0_req_write(req_write[0]),
+      .n0_req_addr(req_addr[0]),
+      .n0_req_tag(req_tag[0]),
+      .n0_req_data_w0(req_data[0][0]),
+      .n0_req_data_w1(req_data[0][1]),
+      .n0_req_data_w2(req_data[0][2]),
+      .n0_req_data_w3(req_data[0][3]),
+      .n0_req_data_w4(req_data[0][4]),
+      .n0_req_data_w5(req_data[0][5]),
+      .n0_req_data_w6(req_data[0][6]),
+      .n0_req_data_w7(req_data[0][7]),
+      .n0_req_data_w8(req_data[0][8]),
+      .n0_req_data_w9(req_data[0][9]),
+      .n0_req_data_w10(req_data[0][10]),
+      .n0_req_data_w11(req_data[0][11]),
+      .n0_req_data_w12(req_data[0][12]),
+      .n0_req_data_w13(req_data[0][13]),
+      .n0_req_data_w14(req_data[0][14]),
+      .n0_req_data_w15(req_data[0][15]),
+      .n0_req_data_w16(req_data[0][16]),
+      .n0_req_data_w17(req_data[0][17]),
+      .n0_req_data_w18(req_data[0][18]),
+      .n0_req_data_w19(req_data[0][19]),
+      .n0_req_data_w20(req_data[0][20]),
+      .n0_req_data_w21(req_data[0][21]),
+      .n0_req_data_w22(req_data[0][22]),
+      .n0_req_data_w23(req_data[0][23]),
+      .n0_req_data_w24(req_data[0][24]),
+      .n0_req_data_w25(req_data[0][25]),
+      .n0_req_data_w26(req_data[0][26]),
+      .n0_req_data_w27(req_data[0][27]),
+      .n0_req_data_w28(req_data[0][28]),
+      .n0_req_data_w29(req_data[0][29]),
+      .n0_req_data_w30(req_data[0][30]),
+      .n0_req_data_w31(req_data[0][31]),
+      .n0_req_ready(req_ready[0]),
+      .n0_resp_ready(resp_ready[0]),
+      .n0_resp_valid(resp_valid[0]),
+      .n0_resp_tag(resp_tag[0]),
+      .n0_resp_data_w0(resp_data[0][0]),
+      .n0_resp_data_w1(resp_data[0][1]),
+      .n0_resp_data_w2(resp_data[0][2]),
+      .n0_resp_data_w3(resp_data[0][3]),
+      .n0_resp_data_w4(resp_data[0][4]),
+      .n0_resp_data_w5(resp_data[0][5]),
+      .n0_resp_data_w6(resp_data[0][6]),
+      .n0_resp_data_w7(resp_data[0][7]),
+      .n0_resp_data_w8(resp_data[0][8]),
+      .n0_resp_data_w9(resp_data[0][9]),
+      .n0_resp_data_w10(resp_data[0][10]),
+      .n0_resp_data_w11(resp_data[0][11]),
+      .n0_resp_data_w12(resp_data[0][12]),
+      .n0_resp_data_w13(resp_data[0][13]),
+      .n0_resp_data_w14(resp_data[0][14]),
+      .n0_resp_data_w15(resp_data[0][15]),
+      .n0_resp_data_w16(resp_data[0][16]),
+      .n0_resp_data_w17(resp_data[0][17]),
+      .n0_resp_data_w18(resp_data[0][18]),
+      .n0_resp_data_w19(resp_data[0][19]),
+      .n0_resp_data_w20(resp_data[0][20]),
+      .n0_resp_data_w21(resp_data[0][21]),
+      .n0_resp_data_w22(resp_data[0][22]),
+      .n0_resp_data_w23(resp_data[0][23]),
+      .n0_resp_data_w24(resp_data[0][24]),
+      .n0_resp_data_w25(resp_data[0][25]),
+      .n0_resp_data_w26(resp_data[0][26]),
+      .n0_resp_data_w27(resp_data[0][27]),
+      .n0_resp_data_w28(resp_data[0][28]),
+      .n0_resp_data_w29(resp_data[0][29]),
+      .n0_resp_data_w30(resp_data[0][30]),
+      .n0_resp_data_w31(resp_data[0][31]),
+      .n0_resp_is_write(resp_is_write[0]),
+
+      .n1_req_valid(req_valid[1]),
+      .n1_req_write(req_write[1]),
+      .n1_req_addr(req_addr[1]),
+      .n1_req_tag(req_tag[1]),
+      .n1_req_data_w0(req_data[1][0]),
+      .n1_req_data_w1(req_data[1][1]),
+      .n1_req_data_w2(req_data[1][2]),
+      .n1_req_data_w3(req_data[1][3]),
+      .n1_req_data_w4(req_data[1][4]),
+      .n1_req_data_w5(req_data[1][5]),
+      .n1_req_data_w6(req_data[1][6]),
+      .n1_req_data_w7(req_data[1][7]),
+      .n1_req_data_w8(req_data[1][8]),
+      .n1_req_data_w9(req_data[1][9]),
+      .n1_req_data_w10(req_data[1][10]),
+      .n1_req_data_w11(req_data[1][11]),
+      .n1_req_data_w12(req_data[1][12]),
+      .n1_req_data_w13(req_data[1][13]),
+      .n1_req_data_w14(req_data[1][14]),
+      .n1_req_data_w15(req_data[1][15]),
+      .n1_req_data_w16(req_data[1][16]),
+      .n1_req_data_w17(req_data[1][17]),
+      .n1_req_data_w18(req_data[1][18]),
+      .n1_req_data_w19(req_data[1][19]),
+      .n1_req_data_w20(req_data[1][20]),
+      .n1_req_data_w21(req_data[1][21]),
+      .n1_req_data_w22(req_data[1][22]),
+      .n1_req_data_w23(req_data[1][23]),
+      .n1_req_data_w24(req_data[1][24]),
+      .n1_req_data_w25(req_data[1][25]),
+      .n1_req_data_w26(req_data[1][26]),
+      .n1_req_data_w27(req_data[1][27]),
+      .n1_req_data_w28(req_data[1][28]),
+      .n1_req_data_w29(req_data[1][29]),
+      .n1_req_data_w30(req_data[1][30]),
+      .n1_req_data_w31(req_data[1][31]),
+      .n1_req_ready(req_ready[1]),
+      .n1_resp_ready(resp_ready[1]),
+      .n1_resp_valid(resp_valid[1]),
+      .n1_resp_tag(resp_tag[1]),
+      .n1_resp_data_w0(resp_data[1][0]),
+      .n1_resp_data_w1(resp_data[1][1]),
+      .n1_resp_data_w2(resp_data[1][2]),
+      .n1_resp_data_w3(resp_data[1][3]),
+      .n1_resp_data_w4(resp_data[1][4]),
+      .n1_resp_data_w5(resp_data[1][5]),
+      .n1_resp_data_w6(resp_data[1][6]),
+      .n1_resp_data_w7(resp_data[1][7]),
+      .n1_resp_data_w8(resp_data[1][8]),
+      .n1_resp_data_w9(resp_data[1][9]),
+      .n1_resp_data_w10(resp_data[1][10]),
+      .n1_resp_data_w11(resp_data[1][11]),
+      .n1_resp_data_w12(resp_data[1][12]),
+      .n1_resp_data_w13(resp_data[1][13]),
+      .n1_resp_data_w14(resp_data[1][14]),
+      .n1_resp_data_w15(resp_data[1][15]),
+      .n1_resp_data_w16(resp_data[1][16]),
+      .n1_resp_data_w17(resp_data[1][17]),
+      .n1_resp_data_w18(resp_data[1][18]),
+      .n1_resp_data_w19(resp_data[1][19]),
+      .n1_resp_data_w20(resp_data[1][20]),
+      .n1_resp_data_w21(resp_data[1][21]),
+      .n1_resp_data_w22(resp_data[1][22]),
+      .n1_resp_data_w23(resp_data[1][23]),
+      .n1_resp_data_w24(resp_data[1][24]),
+      .n1_resp_data_w25(resp_data[1][25]),
+      .n1_resp_data_w26(resp_data[1][26]),
+      .n1_resp_data_w27(resp_data[1][27]),
+      .n1_resp_data_w28(resp_data[1][28]),
+      .n1_resp_data_w29(resp_data[1][29]),
+      .n1_resp_data_w30(resp_data[1][30]),
+      .n1_resp_data_w31(resp_data[1][31]),
+      .n1_resp_is_write(resp_is_write[1]),
+
+      .n2_req_valid(req_valid[2]),
+      .n2_req_write(req_write[2]),
+      .n2_req_addr(req_addr[2]),
+      .n2_req_tag(req_tag[2]),
+      .n2_req_data_w0(req_data[2][0]),
+      .n2_req_data_w1(req_data[2][1]),
+      .n2_req_data_w2(req_data[2][2]),
+      .n2_req_data_w3(req_data[2][3]),
+      .n2_req_data_w4(req_data[2][4]),
+      .n2_req_data_w5(req_data[2][5]),
+      .n2_req_data_w6(req_data[2][6]),
+      .n2_req_data_w7(req_data[2][7]),
+      .n2_req_data_w8(req_data[2][8]),
+      .n2_req_data_w9(req_data[2][9]),
+      .n2_req_data_w10(req_data[2][10]),
+      .n2_req_data_w11(req_data[2][11]),
+      .n2_req_data_w12(req_data[2][12]),
+      .n2_req_data_w13(req_data[2][13]),
+      .n2_req_data_w14(req_data[2][14]),
+      .n2_req_data_w15(req_data[2][15]),
+      .n2_req_data_w16(req_data[2][16]),
+      .n2_req_data_w17(req_data[2][17]),
+      .n2_req_data_w18(req_data[2][18]),
+      .n2_req_data_w19(req_data[2][19]),
+      .n2_req_data_w20(req_data[2][20]),
+      .n2_req_data_w21(req_data[2][21]),
+      .n2_req_data_w22(req_data[2][22]),
+      .n2_req_data_w23(req_data[2][23]),
+      .n2_req_data_w24(req_data[2][24]),
+      .n2_req_data_w25(req_data[2][25]),
+      .n2_req_data_w26(req_data[2][26]),
+      .n2_req_data_w27(req_data[2][27]),
+      .n2_req_data_w28(req_data[2][28]),
+      .n2_req_data_w29(req_data[2][29]),
+      .n2_req_data_w30(req_data[2][30]),
+      .n2_req_data_w31(req_data[2][31]),
+      .n2_req_ready(req_ready[2]),
+      .n2_resp_ready(resp_ready[2]),
+      .n2_resp_valid(resp_valid[2]),
+      .n2_resp_tag(resp_tag[2]),
+      .n2_resp_data_w0(resp_data[2][0]),
+      .n2_resp_data_w1(resp_data[2][1]),
+      .n2_resp_data_w2(resp_data[2][2]),
+      .n2_resp_data_w3(resp_data[2][3]),
+      .n2_resp_data_w4(resp_data[2][4]),
+      .n2_resp_data_w5(resp_data[2][5]),
+      .n2_resp_data_w6(resp_data[2][6]),
+      .n2_resp_data_w7(resp_data[2][7]),
+      .n2_resp_data_w8(resp_data[2][8]),
+      .n2_resp_data_w9(resp_data[2][9]),
+      .n2_resp_data_w10(resp_data[2][10]),
+      .n2_resp_data_w11(resp_data[2][11]),
+      .n2_resp_data_w12(resp_data[2][12]),
+      .n2_resp_data_w13(resp_data[2][13]),
+      .n2_resp_data_w14(resp_data[2][14]),
+      .n2_resp_data_w15(resp_data[2][15]),
+      .n2_resp_data_w16(resp_data[2][16]),
+      .n2_resp_data_w17(resp_data[2][17]),
+      .n2_resp_data_w18(resp_data[2][18]),
+      .n2_resp_data_w19(resp_data[2][19]),
+      .n2_resp_data_w20(resp_data[2][20]),
+      .n2_resp_data_w21(resp_data[2][21]),
+      .n2_resp_data_w22(resp_data[2][22]),
+      .n2_resp_data_w23(resp_data[2][23]),
+      .n2_resp_data_w24(resp_data[2][24]),
+      .n2_resp_data_w25(resp_data[2][25]),
+      .n2_resp_data_w26(resp_data[2][26]),
+      .n2_resp_data_w27(resp_data[2][27]),
+      .n2_resp_data_w28(resp_data[2][28]),
+      .n2_resp_data_w29(resp_data[2][29]),
+      .n2_resp_data_w30(resp_data[2][30]),
+      .n2_resp_data_w31(resp_data[2][31]),
+      .n2_resp_is_write(resp_is_write[2]),
+
+      .n3_req_valid(req_valid[3]),
+      .n3_req_write(req_write[3]),
+      .n3_req_addr(req_addr[3]),
+      .n3_req_tag(req_tag[3]),
+      .n3_req_data_w0(req_data[3][0]),
+      .n3_req_data_w1(req_data[3][1]),
+      .n3_req_data_w2(req_data[3][2]),
+      .n3_req_data_w3(req_data[3][3]),
+      .n3_req_data_w4(req_data[3][4]),
+      .n3_req_data_w5(req_data[3][5]),
+      .n3_req_data_w6(req_data[3][6]),
+      .n3_req_data_w7(req_data[3][7]),
+      .n3_req_data_w8(req_data[3][8]),
+      .n3_req_data_w9(req_data[3][9]),
+      .n3_req_data_w10(req_data[3][10]),
+      .n3_req_data_w11(req_data[3][11]),
+      .n3_req_data_w12(req_data[3][12]),
+      .n3_req_data_w13(req_data[3][13]),
+      .n3_req_data_w14(req_data[3][14]),
+      .n3_req_data_w15(req_data[3][15]),
+      .n3_req_data_w16(req_data[3][16]),
+      .n3_req_data_w17(req_data[3][17]),
+      .n3_req_data_w18(req_data[3][18]),
+      .n3_req_data_w19(req_data[3][19]),
+      .n3_req_data_w20(req_data[3][20]),
+      .n3_req_data_w21(req_data[3][21]),
+      .n3_req_data_w22(req_data[3][22]),
+      .n3_req_data_w23(req_data[3][23]),
+      .n3_req_data_w24(req_data[3][24]),
+      .n3_req_data_w25(req_data[3][25]),
+      .n3_req_data_w26(req_data[3][26]),
+      .n3_req_data_w27(req_data[3][27]),
+      .n3_req_data_w28(req_data[3][28]),
+      .n3_req_data_w29(req_data[3][29]),
+      .n3_req_data_w30(req_data[3][30]),
+      .n3_req_data_w31(req_data[3][31]),
+      .n3_req_ready(req_ready[3]),
+      .n3_resp_ready(resp_ready[3]),
+      .n3_resp_valid(resp_valid[3]),
+      .n3_resp_tag(resp_tag[3]),
+      .n3_resp_data_w0(resp_data[3][0]),
+      .n3_resp_data_w1(resp_data[3][1]),
+      .n3_resp_data_w2(resp_data[3][2]),
+      .n3_resp_data_w3(resp_data[3][3]),
+      .n3_resp_data_w4(resp_data[3][4]),
+      .n3_resp_data_w5(resp_data[3][5]),
+      .n3_resp_data_w6(resp_data[3][6]),
+      .n3_resp_data_w7(resp_data[3][7]),
+      .n3_resp_data_w8(resp_data[3][8]),
+      .n3_resp_data_w9(resp_data[3][9]),
+      .n3_resp_data_w10(resp_data[3][10]),
+      .n3_resp_data_w11(resp_data[3][11]),
+      .n3_resp_data_w12(resp_data[3][12]),
+      .n3_resp_data_w13(resp_data[3][13]),
+      .n3_resp_data_w14(resp_data[3][14]),
+      .n3_resp_data_w15(resp_data[3][15]),
+      .n3_resp_data_w16(resp_data[3][16]),
+      .n3_resp_data_w17(resp_data[3][17]),
+      .n3_resp_data_w18(resp_data[3][18]),
+      .n3_resp_data_w19(resp_data[3][19]),
+      .n3_resp_data_w20(resp_data[3][20]),
+      .n3_resp_data_w21(resp_data[3][21]),
+      .n3_resp_data_w22(resp_data[3][22]),
+      .n3_resp_data_w23(resp_data[3][23]),
+      .n3_resp_data_w24(resp_data[3][24]),
+      .n3_resp_data_w25(resp_data[3][25]),
+      .n3_resp_data_w26(resp_data[3][26]),
+      .n3_resp_data_w27(resp_data[3][27]),
+      .n3_resp_data_w28(resp_data[3][28]),
+      .n3_resp_data_w29(resp_data[3][29]),
+      .n3_resp_data_w30(resp_data[3][30]),
+      .n3_resp_data_w31(resp_data[3][31]),
+      .n3_resp_is_write(resp_is_write[3]),
+
+      .n4_req_valid(req_valid[4]),
+      .n4_req_write(req_write[4]),
+      .n4_req_addr(req_addr[4]),
+      .n4_req_tag(req_tag[4]),
+      .n4_req_data_w0(req_data[4][0]),
+      .n4_req_data_w1(req_data[4][1]),
+      .n4_req_data_w2(req_data[4][2]),
+      .n4_req_data_w3(req_data[4][3]),
+      .n4_req_data_w4(req_data[4][4]),
+      .n4_req_data_w5(req_data[4][5]),
+      .n4_req_data_w6(req_data[4][6]),
+      .n4_req_data_w7(req_data[4][7]),
+      .n4_req_data_w8(req_data[4][8]),
+      .n4_req_data_w9(req_data[4][9]),
+      .n4_req_data_w10(req_data[4][10]),
+      .n4_req_data_w11(req_data[4][11]),
+      .n4_req_data_w12(req_data[4][12]),
+      .n4_req_data_w13(req_data[4][13]),
+      .n4_req_data_w14(req_data[4][14]),
+      .n4_req_data_w15(req_data[4][15]),
+      .n4_req_data_w16(req_data[4][16]),
+      .n4_req_data_w17(req_data[4][17]),
+      .n4_req_data_w18(req_data[4][18]),
+      .n4_req_data_w19(req_data[4][19]),
+      .n4_req_data_w20(req_data[4][20]),
+      .n4_req_data_w21(req_data[4][21]),
+      .n4_req_data_w22(req_data[4][22]),
+      .n4_req_data_w23(req_data[4][23]),
+      .n4_req_data_w24(req_data[4][24]),
+      .n4_req_data_w25(req_data[4][25]),
+      .n4_req_data_w26(req_data[4][26]),
+      .n4_req_data_w27(req_data[4][27]),
+      .n4_req_data_w28(req_data[4][28]),
+      .n4_req_data_w29(req_data[4][29]),
+      .n4_req_data_w30(req_data[4][30]),
+      .n4_req_data_w31(req_data[4][31]),
+      .n4_req_ready(req_ready[4]),
+      .n4_resp_ready(resp_ready[4]),
+      .n4_resp_valid(resp_valid[4]),
+      .n4_resp_tag(resp_tag[4]),
+      .n4_resp_data_w0(resp_data[4][0]),
+      .n4_resp_data_w1(resp_data[4][1]),
+      .n4_resp_data_w2(resp_data[4][2]),
+      .n4_resp_data_w3(resp_data[4][3]),
+      .n4_resp_data_w4(resp_data[4][4]),
+      .n4_resp_data_w5(resp_data[4][5]),
+      .n4_resp_data_w6(resp_data[4][6]),
+      .n4_resp_data_w7(resp_data[4][7]),
+      .n4_resp_data_w8(resp_data[4][8]),
+      .n4_resp_data_w9(resp_data[4][9]),
+      .n4_resp_data_w10(resp_data[4][10]),
+      .n4_resp_data_w11(resp_data[4][11]),
+      .n4_resp_data_w12(resp_data[4][12]),
+      .n4_resp_data_w13(resp_data[4][13]),
+      .n4_resp_data_w14(resp_data[4][14]),
+      .n4_resp_data_w15(resp_data[4][15]),
+      .n4_resp_data_w16(resp_data[4][16]),
+      .n4_resp_data_w17(resp_data[4][17]),
+      .n4_resp_data_w18(resp_data[4][18]),
+      .n4_resp_data_w19(resp_data[4][19]),
+      .n4_resp_data_w20(resp_data[4][20]),
+      .n4_resp_data_w21(resp_data[4][21]),
+      .n4_resp_data_w22(resp_data[4][22]),
+      .n4_resp_data_w23(resp_data[4][23]),
+      .n4_resp_data_w24(resp_data[4][24]),
+      .n4_resp_data_w25(resp_data[4][25]),
+      .n4_resp_data_w26(resp_data[4][26]),
+      .n4_resp_data_w27(resp_data[4][27]),
+      .n4_resp_data_w28(resp_data[4][28]),
+      .n4_resp_data_w29(resp_data[4][29]),
+      .n4_resp_data_w30(resp_data[4][30]),
+      .n4_resp_data_w31(resp_data[4][31]),
+      .n4_resp_is_write(resp_is_write[4]),
+
+      .n5_req_valid(req_valid[5]),
+      .n5_req_write(req_write[5]),
+      .n5_req_addr(req_addr[5]),
+      .n5_req_tag(req_tag[5]),
+      .n5_req_data_w0(req_data[5][0]),
+      .n5_req_data_w1(req_data[5][1]),
+      .n5_req_data_w2(req_data[5][2]),
+      .n5_req_data_w3(req_data[5][3]),
+      .n5_req_data_w4(req_data[5][4]),
+      .n5_req_data_w5(req_data[5][5]),
+      .n5_req_data_w6(req_data[5][6]),
+      .n5_req_data_w7(req_data[5][7]),
+      .n5_req_data_w8(req_data[5][8]),
+      .n5_req_data_w9(req_data[5][9]),
+      .n5_req_data_w10(req_data[5][10]),
+      .n5_req_data_w11(req_data[5][11]),
+      .n5_req_data_w12(req_data[5][12]),
+      .n5_req_data_w13(req_data[5][13]),
+      .n5_req_data_w14(req_data[5][14]),
+      .n5_req_data_w15(req_data[5][15]),
+      .n5_req_data_w16(req_data[5][16]),
+      .n5_req_data_w17(req_data[5][17]),
+      .n5_req_data_w18(req_data[5][18]),
+      .n5_req_data_w19(req_data[5][19]),
+      .n5_req_data_w20(req_data[5][20]),
+      .n5_req_data_w21(req_data[5][21]),
+      .n5_req_data_w22(req_data[5][22]),
+      .n5_req_data_w23(req_data[5][23]),
+      .n5_req_data_w24(req_data[5][24]),
+      .n5_req_data_w25(req_data[5][25]),
+      .n5_req_data_w26(req_data[5][26]),
+      .n5_req_data_w27(req_data[5][27]),
+      .n5_req_data_w28(req_data[5][28]),
+      .n5_req_data_w29(req_data[5][29]),
+      .n5_req_data_w30(req_data[5][30]),
+      .n5_req_data_w31(req_data[5][31]),
+      .n5_req_ready(req_ready[5]),
+      .n5_resp_ready(resp_ready[5]),
+      .n5_resp_valid(resp_valid[5]),
+      .n5_resp_tag(resp_tag[5]),
+      .n5_resp_data_w0(resp_data[5][0]),
+      .n5_resp_data_w1(resp_data[5][1]),
+      .n5_resp_data_w2(resp_data[5][2]),
+      .n5_resp_data_w3(resp_data[5][3]),
+      .n5_resp_data_w4(resp_data[5][4]),
+      .n5_resp_data_w5(resp_data[5][5]),
+      .n5_resp_data_w6(resp_data[5][6]),
+      .n5_resp_data_w7(resp_data[5][7]),
+      .n5_resp_data_w8(resp_data[5][8]),
+      .n5_resp_data_w9(resp_data[5][9]),
+      .n5_resp_data_w10(resp_data[5][10]),
+      .n5_resp_data_w11(resp_data[5][11]),
+      .n5_resp_data_w12(resp_data[5][12]),
+      .n5_resp_data_w13(resp_data[5][13]),
+      .n5_resp_data_w14(resp_data[5][14]),
+      .n5_resp_data_w15(resp_data[5][15]),
+      .n5_resp_data_w16(resp_data[5][16]),
+      .n5_resp_data_w17(resp_data[5][17]),
+      .n5_resp_data_w18(resp_data[5][18]),
+      .n5_resp_data_w19(resp_data[5][19]),
+      .n5_resp_data_w20(resp_data[5][20]),
+      .n5_resp_data_w21(resp_data[5][21]),
+      .n5_resp_data_w22(resp_data[5][22]),
+      .n5_resp_data_w23(resp_data[5][23]),
+      .n5_resp_data_w24(resp_data[5][24]),
+      .n5_resp_data_w25(resp_data[5][25]),
+      .n5_resp_data_w26(resp_data[5][26]),
+      .n5_resp_data_w27(resp_data[5][27]),
+      .n5_resp_data_w28(resp_data[5][28]),
+      .n5_resp_data_w29(resp_data[5][29]),
+      .n5_resp_data_w30(resp_data[5][30]),
+      .n5_resp_data_w31(resp_data[5][31]),
+      .n5_resp_is_write(resp_is_write[5]),
+
+      .n6_req_valid(req_valid[6]),
+      .n6_req_write(req_write[6]),
+      .n6_req_addr(req_addr[6]),
+      .n6_req_tag(req_tag[6]),
+      .n6_req_data_w0(req_data[6][0]),
+      .n6_req_data_w1(req_data[6][1]),
+      .n6_req_data_w2(req_data[6][2]),
+      .n6_req_data_w3(req_data[6][3]),
+      .n6_req_data_w4(req_data[6][4]),
+      .n6_req_data_w5(req_data[6][5]),
+      .n6_req_data_w6(req_data[6][6]),
+      .n6_req_data_w7(req_data[6][7]),
+      .n6_req_data_w8(req_data[6][8]),
+      .n6_req_data_w9(req_data[6][9]),
+      .n6_req_data_w10(req_data[6][10]),
+      .n6_req_data_w11(req_data[6][11]),
+      .n6_req_data_w12(req_data[6][12]),
+      .n6_req_data_w13(req_data[6][13]),
+      .n6_req_data_w14(req_data[6][14]),
+      .n6_req_data_w15(req_data[6][15]),
+      .n6_req_data_w16(req_data[6][16]),
+      .n6_req_data_w17(req_data[6][17]),
+      .n6_req_data_w18(req_data[6][18]),
+      .n6_req_data_w19(req_data[6][19]),
+      .n6_req_data_w20(req_data[6][20]),
+      .n6_req_data_w21(req_data[6][21]),
+      .n6_req_data_w22(req_data[6][22]),
+      .n6_req_data_w23(req_data[6][23]),
+      .n6_req_data_w24(req_data[6][24]),
+      .n6_req_data_w25(req_data[6][25]),
+      .n6_req_data_w26(req_data[6][26]),
+      .n6_req_data_w27(req_data[6][27]),
+      .n6_req_data_w28(req_data[6][28]),
+      .n6_req_data_w29(req_data[6][29]),
+      .n6_req_data_w30(req_data[6][30]),
+      .n6_req_data_w31(req_data[6][31]),
+      .n6_req_ready(req_ready[6]),
+      .n6_resp_ready(resp_ready[6]),
+      .n6_resp_valid(resp_valid[6]),
+      .n6_resp_tag(resp_tag[6]),
+      .n6_resp_data_w0(resp_data[6][0]),
+      .n6_resp_data_w1(resp_data[6][1]),
+      .n6_resp_data_w2(resp_data[6][2]),
+      .n6_resp_data_w3(resp_data[6][3]),
+      .n6_resp_data_w4(resp_data[6][4]),
+      .n6_resp_data_w5(resp_data[6][5]),
+      .n6_resp_data_w6(resp_data[6][6]),
+      .n6_resp_data_w7(resp_data[6][7]),
+      .n6_resp_data_w8(resp_data[6][8]),
+      .n6_resp_data_w9(resp_data[6][9]),
+      .n6_resp_data_w10(resp_data[6][10]),
+      .n6_resp_data_w11(resp_data[6][11]),
+      .n6_resp_data_w12(resp_data[6][12]),
+      .n6_resp_data_w13(resp_data[6][13]),
+      .n6_resp_data_w14(resp_data[6][14]),
+      .n6_resp_data_w15(resp_data[6][15]),
+      .n6_resp_data_w16(resp_data[6][16]),
+      .n6_resp_data_w17(resp_data[6][17]),
+      .n6_resp_data_w18(resp_data[6][18]),
+      .n6_resp_data_w19(resp_data[6][19]),
+      .n6_resp_data_w20(resp_data[6][20]),
+      .n6_resp_data_w21(resp_data[6][21]),
+      .n6_resp_data_w22(resp_data[6][22]),
+      .n6_resp_data_w23(resp_data[6][23]),
+      .n6_resp_data_w24(resp_data[6][24]),
+      .n6_resp_data_w25(resp_data[6][25]),
+      .n6_resp_data_w26(resp_data[6][26]),
+      .n6_resp_data_w27(resp_data[6][27]),
+      .n6_resp_data_w28(resp_data[6][28]),
+      .n6_resp_data_w29(resp_data[6][29]),
+      .n6_resp_data_w30(resp_data[6][30]),
+      .n6_resp_data_w31(resp_data[6][31]),
+      .n6_resp_is_write(resp_is_write[6]),
+
+      .n7_req_valid(req_valid[7]),
+      .n7_req_write(req_write[7]),
+      .n7_req_addr(req_addr[7]),
+      .n7_req_tag(req_tag[7]),
+      .n7_req_data_w0(req_data[7][0]),
+      .n7_req_data_w1(req_data[7][1]),
+      .n7_req_data_w2(req_data[7][2]),
+      .n7_req_data_w3(req_data[7][3]),
+      .n7_req_data_w4(req_data[7][4]),
+      .n7_req_data_w5(req_data[7][5]),
+      .n7_req_data_w6(req_data[7][6]),
+      .n7_req_data_w7(req_data[7][7]),
+      .n7_req_data_w8(req_data[7][8]),
+      .n7_req_data_w9(req_data[7][9]),
+      .n7_req_data_w10(req_data[7][10]),
+      .n7_req_data_w11(req_data[7][11]),
+      .n7_req_data_w12(req_data[7][12]),
+      .n7_req_data_w13(req_data[7][13]),
+      .n7_req_data_w14(req_data[7][14]),
+      .n7_req_data_w15(req_data[7][15]),
+      .n7_req_data_w16(req_data[7][16]),
+      .n7_req_data_w17(req_data[7][17]),
+      .n7_req_data_w18(req_data[7][18]),
+      .n7_req_data_w19(req_data[7][19]),
+      .n7_req_data_w20(req_data[7][20]),
+      .n7_req_data_w21(req_data[7][21]),
+      .n7_req_data_w22(req_data[7][22]),
+      .n7_req_data_w23(req_data[7][23]),
+      .n7_req_data_w24(req_data[7][24]),
+      .n7_req_data_w25(req_data[7][25]),
+      .n7_req_data_w26(req_data[7][26]),
+      .n7_req_data_w27(req_data[7][27]),
+      .n7_req_data_w28(req_data[7][28]),
+      .n7_req_data_w29(req_data[7][29]),
+      .n7_req_data_w30(req_data[7][30]),
+      .n7_req_data_w31(req_data[7][31]),
+      .n7_req_ready(req_ready[7]),
+      .n7_resp_ready(resp_ready[7]),
+      .n7_resp_valid(resp_valid[7]),
+      .n7_resp_tag(resp_tag[7]),
+      .n7_resp_data_w0(resp_data[7][0]),
+      .n7_resp_data_w1(resp_data[7][1]),
+      .n7_resp_data_w2(resp_data[7][2]),
+      .n7_resp_data_w3(resp_data[7][3]),
+      .n7_resp_data_w4(resp_data[7][4]),
+      .n7_resp_data_w5(resp_data[7][5]),
+      .n7_resp_data_w6(resp_data[7][6]),
+      .n7_resp_data_w7(resp_data[7][7]),
+      .n7_resp_data_w8(resp_data[7][8]),
+      .n7_resp_data_w9(resp_data[7][9]),
+      .n7_resp_data_w10(resp_data[7][10]),
+      .n7_resp_data_w11(resp_data[7][11]),
+      .n7_resp_data_w12(resp_data[7][12]),
+      .n7_resp_data_w13(resp_data[7][13]),
+      .n7_resp_data_w14(resp_data[7][14]),
+      .n7_resp_data_w15(resp_data[7][15]),
+      .n7_resp_data_w16(resp_data[7][16]),
+      .n7_resp_data_w17(resp_data[7][17]),
+      .n7_resp_data_w18(resp_data[7][18]),
+      .n7_resp_data_w19(resp_data[7][19]),
+      .n7_resp_data_w20(resp_data[7][20]),
+      .n7_resp_data_w21(resp_data[7][21]),
+      .n7_resp_data_w22(resp_data[7][22]),
+      .n7_resp_data_w23(resp_data[7][23]),
+      .n7_resp_data_w24(resp_data[7][24]),
+      .n7_resp_data_w25(resp_data[7][25]),
+      .n7_resp_data_w26(resp_data[7][26]),
+      .n7_resp_data_w27(resp_data[7][27]),
+      .n7_resp_data_w28(resp_data[7][28]),
+      .n7_resp_data_w29(resp_data[7][29]),
+      .n7_resp_data_w30(resp_data[7][30]),
+      .n7_resp_data_w31(resp_data[7][31]),
+      .n7_resp_is_write(resp_is_write[7])
+  );
+
+  function automatic [19:0] make_addr(input int index, input int pipe, input int offset);
+    make_addr = {index[8:0], pipe[2:0], offset[7:0]};
+  endfunction
+
+  task automatic fill_data(output logic [63:0] data[0:31], input int seed);
+    integer i;
+    begin
+      for (i = 0; i < 32; i = i + 1) begin
+        data[i] = {seed[31:0], i[31:0]};
+      end
+    end
+  endtask
+
+  task automatic clear_line(output logic [63:0] data[0:31]);
+    integer i;
+    begin
+      for (i = 0; i < 32; i = i + 1) begin
+        data[i] = 64'd0;
+      end
+    end
+  endtask
+
+  task automatic clear_reqs();
+    integer i;
+    integer j;
+    begin
+      for (i = 0; i < 8; i = i + 1) begin
+        req_valid[i] = 1'b0;
+        req_write[i] = 1'b0;
+        req_addr[i] = 20'd0;
+        req_tag[i] = 8'd0;
+        resp_ready[i] = 1'b1;
+        for (j = 0; j < 32; j = j + 1) begin
+          req_data[i][j] = 64'd0;
+        end
+      end
+    end
+  endtask
+
+  task automatic send_req(
+      input int node,
+      input bit write,
+      input logic [19:0] addr,
+      input logic [7:0] tag,
+      input logic [63:0] data[0:31]
+  );
+    integer i;
+    begin
+      req_write[node] = write;
+      req_addr[node] = addr;
+      req_tag[node] = tag;
+      for (i = 0; i < 32; i = i + 1) begin
+        req_data[node][i] = data[i];
+      end
+      req_valid[node] = 1'b1;
+      while (req_ready[node] !== 1'b1) begin
+        @(posedge clk);
+      end
+      @(posedge clk);
+      req_valid[node] = 1'b0;
+    end
+  endtask
+
+  task automatic wait_resp(
+      input int node,
+      input logic [7:0] tag,
+      input bit expect_write,
+      input logic [63:0] expect_data[0:31]
+  );
+    integer timeout;
+    integer i;
+    begin
+      timeout = 2000;
+      while (timeout > 0) begin
+        @(posedge clk);
+        if (resp_valid[node]) begin
+          if (resp_tag[node] !== tag) $fatal(1, "tag mismatch");
+          if (resp_is_write[node] !== expect_write) $fatal(1, "resp_is_write mismatch");
+          for (i = 0; i < 32; i = i + 1) begin
+            if (resp_data[node][i] !== expect_data[i]) $fatal(1, "resp_data mismatch");
+          end
+          return;
+        end
+        timeout = timeout - 1;
+      end
+      $fatal(1, "timeout waiting resp");
+    end
+  endtask
+
+  initial begin
+    clk = 1'b0;
+    rst = 1'b1;
+    clear_reqs();
+    repeat (2) @(posedge clk);
+    rst = 1'b0;
+    repeat (1) @(posedge clk);
+
+    for (int n = 0; n < 8; n = n + 1) begin
+      fill_data(line_data, n + 1);
+      clear_line(line_zero);
+      send_req(n, 1'b1, make_addr(n, n, 0), n[7:0], line_data);
+      wait_resp(n, n[7:0], 1'b1, line_data);
+      send_req(n, 1'b0, make_addr(n, n, 0), (8'h80 | n[7:0]), line_zero);
+      wait_resp(n, (8'h80 | n[7:0]), 1'b0, line_data);
+    end
+
+    begin
+      fill_data(line_data, 8'hAA);
+      clear_line(line_zero);
+      send_req(0, 1'b1, make_addr(5, 2, 0), 8'h55, line_data);
+      wait_resp(0, 8'h55, 1'b1, line_data);
+      send_req(0, 1'b0, make_addr(5, 2, 0), 8'h56, line_zero);
+      wait_resp(0, 8'h56, 1'b0, line_data);
+    end
+
+    $display("PASS: TMU tests");
+    $finish;
+  end
+
+  always #1 clk = ~clk;
+
+  initial begin
+    if (!$test$plusargs("NOVCD")) begin
+      $dumpfile("janus/generated/janus_tmu_pyc/tb_janus_tmu_pyc.vcd");
+      $dumpvars(0, tb_janus_tmu_pyc);
+    end
+  end
+endmodule

--- a/janus/tools/animate_tmu_ring_vcd.py
+++ b/janus/tools/animate_tmu_ring_vcd.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+import argparse
+import math
+from pathlib import Path
+
+RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]
+
+
+def ring_positions(center_x, center_y, radius):
+    positions = {}
+    n = len(RING_ORDER)
+    for i, node in enumerate(RING_ORDER):
+        angle = (2.0 * math.pi * i / n) - (math.pi / 2.0)
+        x = center_x + radius * math.cos(angle)
+        y = center_y + radius * math.sin(angle)
+        positions[node] = (x, y)
+    return positions
+
+
+def parse_vcd(path: Path, watch_names, max_cycles=None, skip_cycles=0):
+    watch_names = set(watch_names)
+    id_to_name = {}
+    values = {name: "0" for name in watch_names}
+    snapshots = []
+
+    with path.open() as f:
+        in_header = True
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if in_header:
+                if line.startswith("$var"):
+                    parts = line.split()
+                    if len(parts) >= 5:
+                        code = parts[3]
+                        name = parts[4]
+                        if name in watch_names:
+                            id_to_name[code] = name
+                elif line.startswith("$enddefinitions"):
+                    in_header = False
+                continue
+
+            # body parsing
+            if line[0] == "#":
+                time = int(line[1:])
+                continue
+            val = line[0]
+            if val not in "01xXzZ":
+                continue
+            code = line[1:]
+            name = id_to_name.get(code)
+            if name is None:
+                continue
+            values[name] = "0" if val in "xXzZ" else val
+
+            # detect posedge from clk updates
+            if name == "clk" and val == "1":
+                if skip_cycles > 0:
+                    skip_cycles -= 1
+                    continue
+                snap = {k: values.get(k, "0") for k in watch_names}
+                snapshots.append(snap)
+                if max_cycles is not None and len(snapshots) >= max_cycles:
+                    break
+
+    return snapshots
+
+
+def emit_token(lines, token_id, start_xy, end_xy, begin_s, dur_s, color, shape, label, glow_id):
+    x0, y0 = start_xy
+    x1, y1 = end_xy
+    if shape == "circle":
+        lines.append(
+            f"<circle id='{token_id}' cx='{x0:.2f}' cy='{y0:.2f}' r='7' fill='{color}' filter='url(#{glow_id})' stroke='#0f172a' stroke-width='1'>"
+        )
+    else:
+        size = 8
+        points = [
+            f"{x0:.2f},{y0 - size:.2f}",
+            f"{x0 + size:.2f},{y0:.2f}",
+            f"{x0:.2f},{y0 + size:.2f}",
+            f"{x0 - size:.2f},{y0:.2f}",
+        ]
+        lines.append(
+            f"<polygon id='{token_id}' points='{' '.join(points)}' fill='{color}' filter='url(#{glow_id})' stroke='#0f172a' stroke-width='1'>"
+        )
+    lines.append(f"<title>{label}</title>")
+    lines.append(
+        f"<animate attributeName='opacity' values='0;1;1;0' keyTimes='0;0.02;0.98;1' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append(
+        f"<animate attributeName='cx' values='{x0:.2f};{x1:.2f}' keyTimes='0;1' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append(
+        f"<animate attributeName='cy' values='{y0:.2f};{y1:.2f}' keyTimes='0;1' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append("</circle>" if shape == "circle" else "</polygon>")
+
+
+def render_svg(snapshots, out_path: Path, cycle_time):
+    width = 980
+    height = 720
+    cx = width / 2
+    cy = height / 2 + 10
+
+    req_radius = 230
+    rsp_radius = 280
+
+    req_pos = ring_positions(cx, cy, req_radius)
+    rsp_pos = ring_positions(cx, cy, rsp_radius)
+
+    next_map = {RING_ORDER[i]: RING_ORDER[(i + 1) % len(RING_ORDER)] for i in range(len(RING_ORDER))}
+    prev_map = {RING_ORDER[i]: RING_ORDER[(i - 1) % len(RING_ORDER)] for i in range(len(RING_ORDER))}
+
+    lines = []
+    lines.append(
+        f"<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}'>"
+    )
+    lines.append("<rect x='0' y='0' width='100%' height='100%' fill='#0b1020' />")
+    lines.append(
+        "<style>"
+        "text{font-family:monospace;fill:#e2e8f0;}"
+        ".title{font-size:18px;font-weight:bold;}"
+        ".legend{font-size:12px;fill:#c7d2fe;}"
+        ".node{fill:#111827;stroke:#94a3b8;stroke-width:2;}"
+        ".ring{stroke:#1e293b;stroke-width:10;fill:none;}"
+        ".ring-rsp{stroke:#243247;stroke-width:10;fill:none;}"
+        ".edge{stroke:#1f2937;stroke-width:2;opacity:0.6;}"
+        "</style>"
+    )
+
+    lines.append(
+        "<defs>"
+        "<filter id='glow_req' x='-50%' y='-50%' width='200%' height='200%'>"
+        "<feGaussianBlur stdDeviation='3' result='blur'/>"
+        "<feMerge><feMergeNode in='blur'/><feMergeNode in='SourceGraphic'/></feMerge>"
+        "</filter>"
+        "<filter id='glow_rsp' x='-50%' y='-50%' width='200%' height='200%'>"
+        "<feGaussianBlur stdDeviation='3' result='blur'/>"
+        "<feMerge><feMergeNode in='blur'/><feMergeNode in='SourceGraphic'/></feMerge>"
+        "</filter>"
+        "</defs>"
+    )
+
+    lines.append(f"<text class='title' x='30' y='36'>TMU ring flow (from VCD)</text>")
+    lines.append(
+        f"<text class='legend' x='30' y='58'>req cw/cc = blue/cyan • rsp cw/cc = green/lime • {cycle_time:.2f}s per cycle</text>"
+    )
+
+    lines.append(f"<circle class='ring' cx='{cx:.2f}' cy='{cy:.2f}' r='{req_radius:.2f}' />")
+    lines.append(f"<circle class='ring-rsp' cx='{cx:.2f}' cy='{cy:.2f}' r='{rsp_radius:.2f}' />")
+
+    for i in range(len(RING_ORDER)):
+        a = RING_ORDER[i]
+        b = RING_ORDER[(i + 1) % len(RING_ORDER)]
+        x1, y1 = req_pos[a]
+        x2, y2 = req_pos[b]
+        lines.append(f"<line class='edge' x1='{x1:.2f}' y1='{y1:.2f}' x2='{x2:.2f}' y2='{y2:.2f}' />")
+
+    for node, (x, y) in req_pos.items():
+        lines.append(f"<circle class='node' cx='{x:.2f}' cy='{y:.2f}' r='26' />")
+        lines.append(f"<text x='{x - 12:.2f}' y='{y + 4:.2f}'>n{node}</text>")
+
+    for cyc, snap in enumerate(snapshots):
+        begin = cyc * cycle_time
+        dur = cycle_time
+        for nid in range(8):
+            # requests on inner ring
+            if snap.get(f"dbg_req_cw_v{nid}") == "1":
+                start = req_pos[nid]
+                end = req_pos[next_map[nid]]
+                emit_token(
+                    lines,
+                    f"req_cw_{cyc}_{nid}",
+                    start,
+                    end,
+                    begin,
+                    dur,
+                    "#38bdf8",
+                    "circle",
+                    f"req cw node={nid} cycle={cyc}",
+                    "glow_req",
+                )
+            if snap.get(f"dbg_req_cc_v{nid}") == "1":
+                start = req_pos[nid]
+                end = req_pos[prev_map[nid]]
+                emit_token(
+                    lines,
+                    f"req_cc_{cyc}_{nid}",
+                    start,
+                    end,
+                    begin,
+                    dur,
+                    "#22d3ee",
+                    "circle",
+                    f"req cc node={nid} cycle={cyc}",
+                    "glow_req",
+                )
+
+            # responses on outer ring
+            if snap.get(f"dbg_rsp_cw_v{nid}") == "1":
+                start = rsp_pos[nid]
+                end = rsp_pos[next_map[nid]]
+                emit_token(
+                    lines,
+                    f"rsp_cw_{cyc}_{nid}",
+                    start,
+                    end,
+                    begin,
+                    dur,
+                    "#22c55e",
+                    "diamond",
+                    f"rsp cw node={nid} cycle={cyc}",
+                    "glow_rsp",
+                )
+            if snap.get(f"dbg_rsp_cc_v{nid}") == "1":
+                start = rsp_pos[nid]
+                end = rsp_pos[prev_map[nid]]
+                emit_token(
+                    lines,
+                    f"rsp_cc_{cyc}_{nid}",
+                    start,
+                    end,
+                    begin,
+                    dur,
+                    "#a3e635",
+                    "diamond",
+                    f"rsp cc node={nid} cycle={cyc}",
+                    "glow_rsp",
+                )
+
+    lines.append("</svg>")
+    out_path.write_text("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Animate TMU ring flows from VCD debug signals.")
+    parser.add_argument("vcd", type=Path, help="Path to VCD (tb_janus_tmu_pyc_cpp.vcd)")
+    parser.add_argument("-o", "--out", type=Path, default=Path("tmu_flow_real.svg"), help="Output SVG")
+    parser.add_argument("--cycle", type=float, default=0.20, help="Seconds per cycle")
+    parser.add_argument("--max-cycles", type=int, default=None, help="Limit cycles")
+    parser.add_argument("--skip-cycles", type=int, default=0, help="Skip initial cycles")
+    args = parser.parse_args()
+
+    watch = ["clk"]
+    for n in range(8):
+        watch.append(f"dbg_req_cw_v{n}")
+        watch.append(f"dbg_req_cc_v{n}")
+        watch.append(f"dbg_rsp_cw_v{n}")
+        watch.append(f"dbg_rsp_cc_v{n}")
+
+    snapshots = parse_vcd(args.vcd, watch, max_cycles=args.max_cycles, skip_cycles=args.skip_cycles)
+    if not snapshots:
+        raise SystemExit("no snapshots found (check VCD path or signals)")
+
+    render_svg(snapshots, args.out, args.cycle)
+
+
+if __name__ == "__main__":
+    main()

--- a/janus/tools/animate_tmu_trace.py
+++ b/janus/tools/animate_tmu_trace.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import math
+from collections import defaultdict, deque
+from pathlib import Path
+
+RING_ORDER = [0, 1, 3, 5, 7, 6, 4, 2]
+
+
+def parse_int(text: str) -> int:
+    text = text.strip()
+    if text.startswith("0x") or text.startswith("0X"):
+        return int(text, 16)
+    return int(text, 10)
+
+
+def load_transactions(path: Path):
+    accepts = defaultdict(deque)
+    transactions = []
+    max_cycle = 0
+
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if not row:
+                continue
+            try:
+                cycle = int(row.get("cycle", "0"))
+                node = int(row.get("node", "0"))
+                tag = int(row.get("tag", "0"))
+                write = int(row.get("write", "0"))
+            except ValueError:
+                continue
+            event = row.get("event", "")
+            if cycle > max_cycle:
+                max_cycle = cycle
+            if event == "accept":
+                addr_text = row.get("addr_or_word0", "0")
+                try:
+                    addr = parse_int(addr_text)
+                except ValueError:
+                    addr = 0
+                accepts[(node, tag)].append({
+                    "cycle": cycle,
+                    "node": node,
+                    "tag": tag,
+                    "write": write,
+                    "addr": addr,
+                })
+            elif event == "resp":
+                key = (node, tag)
+                if not accepts[key]:
+                    continue
+                acc = accepts[key].popleft()
+                transactions.append({
+                    "src": acc["node"],
+                    "dst": (acc["addr"] >> 8) & 0x7,
+                    "cycle_accept": acc["cycle"],
+                    "cycle_resp": cycle,
+                    "tag": tag,
+                    "write": acc["write"],
+                })
+
+    return transactions, max_cycle
+
+
+def ring_positions(center_x, center_y, radius):
+    positions = {}
+    n = len(RING_ORDER)
+    for i, node in enumerate(RING_ORDER):
+        angle = (2.0 * math.pi * i / n) - (math.pi / 2.0)
+        x = center_x + radius * math.cos(angle)
+        y = center_y + radius * math.sin(angle)
+        positions[node] = (x, y)
+    return positions
+
+
+def path_nodes(src, dst):
+    if src == dst:
+        return [src]
+    n = len(RING_ORDER)
+    pos = {node: i for i, node in enumerate(RING_ORDER)}
+    s = pos[src]
+    d = pos[dst]
+    cw = (d - s) % n
+    cc = (s - d) % n
+    if cw <= cc:
+        step = 1
+        dist = cw
+    else:
+        step = -1
+        dist = cc
+    nodes = []
+    idx = s
+    for _ in range(dist + 1):
+        nodes.append(RING_ORDER[idx])
+        idx = (idx + step) % n
+    return nodes
+
+
+def ensure_anim_coords(coords):
+    if len(coords) == 1:
+        return [coords[0], coords[0]]
+    return coords
+
+
+def emit_token(lines, token_id, coords, begin_s, dur_s, color, shape, label):
+    coords = ensure_anim_coords(coords)
+    xs = ";".join(f"{x:.2f}" for x, _ in coords)
+    ys = ";".join(f"{y:.2f}" for _, y in coords)
+    key_times = ";".join(f"{i / (len(coords) - 1):.3f}" for i in range(len(coords)))
+    if shape == "circle":
+        lines.append(f"<circle id='{token_id}' cx='{coords[0][0]:.2f}' cy='{coords[0][1]:.2f}' r='6' fill='{color}' stroke='#111827' stroke-width='1'>")
+    else:
+        size = 7
+        x0, y0 = coords[0]
+        points = [
+            f"{x0:.2f},{y0 - size:.2f}",
+            f"{x0 + size:.2f},{y0:.2f}",
+            f"{x0:.2f},{y0 + size:.2f}",
+            f"{x0 - size:.2f},{y0:.2f}",
+        ]
+        lines.append(f"<polygon id='{token_id}' points='{' '.join(points)}' fill='{color}' stroke='#111827' stroke-width='1'>")
+    lines.append(f"<title>{label}</title>")
+    lines.append(
+        f"<animate attributeName='opacity' values='0;1;1;0' keyTimes='0;0.02;0.98;1' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append(
+        f"<animate attributeName='cx' values='{xs}' keyTimes='{key_times}' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append(
+        f"<animate attributeName='cy' values='{ys}' keyTimes='{key_times}' begin='{begin_s:.2f}s' dur='{dur_s:.2f}s' fill='freeze' />"
+    )
+    lines.append("</circle>" if shape == "circle" else "</polygon>")
+
+
+def render_svg(transactions, max_cycle, out_path: Path, cycle_time):
+    width = 900
+    height = 650
+    cx = width / 2
+    cy = height / 2
+    radius = 230
+
+    positions = ring_positions(cx, cy, radius)
+
+    lines = []
+    lines.append(
+        f"<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}'>"
+    )
+    lines.append("<rect x='0' y='0' width='100%' height='100%' fill='#0f172a' />")
+    lines.append(
+        "<style>"
+        "text{font-family:monospace;fill:#e2e8f0;}"
+        ".title{font-size:16px;font-weight:bold;}"
+        ".legend{font-size:12px;fill:#cbd5f5;}"
+        ".node{fill:#111827;stroke:#94a3b8;stroke-width:2;}"
+        ".ring{stroke:#334155;stroke-width:8;fill:none;}"
+        ".edge{stroke:#1f2937;stroke-width:2;opacity:0.6;}"
+        "</style>"
+    )
+    lines.append("<circle class='ring' cx='{:.2f}' cy='{:.2f}' r='{:.2f}' />".format(cx, cy, radius))
+    lines.append("<text class='title' x='30' y='36'>TMU ring flow animation</text>")
+    lines.append("<text class='legend' x='30' y='56'>blue=accept(req), green=resp</text>")
+
+    for i in range(len(RING_ORDER)):
+        a = RING_ORDER[i]
+        b = RING_ORDER[(i + 1) % len(RING_ORDER)]
+        x1, y1 = positions[a]
+        x2, y2 = positions[b]
+        lines.append(f"<line class='edge' x1='{x1:.2f}' y1='{y1:.2f}' x2='{x2:.2f}' y2='{y2:.2f}' />")
+
+    for node, (x, y) in positions.items():
+        lines.append(f"<circle class='node' cx='{x:.2f}' cy='{y:.2f}' r='26' />")
+        lines.append(f"<text x='{x - 12:.2f}' y='{y + 4:.2f}'>n{node}</text>")
+
+    tpc = cycle_time
+    for idx, tr in enumerate(transactions):
+        src = tr["src"]
+        dst = tr["dst"]
+        c0 = tr["cycle_accept"]
+        c1 = tr["cycle_resp"]
+        tag = tr["tag"]
+        write = tr["write"]
+
+        req_nodes = path_nodes(src, dst)
+        req_coords = [positions[n] for n in req_nodes]
+        req_hops = max(len(req_coords) - 1, 1)
+        req_dur = req_hops * tpc
+        req_begin = c0 * tpc
+        req_label = f"req tag={tag} src={src} dst={dst} w={write}"
+        emit_token(
+            lines,
+            f"req_{idx}",
+            req_coords,
+            req_begin,
+            req_dur,
+            "#38bdf8",
+            "circle",
+            req_label,
+        )
+
+        rsp_nodes = path_nodes(dst, src)
+        rsp_coords = [positions[n] for n in rsp_nodes]
+        rsp_hops = max(len(rsp_coords) - 1, 1)
+        rsp_dur = rsp_hops * tpc
+        rsp_end = c1 * tpc
+        rsp_begin = max(req_begin + req_dur, rsp_end - rsp_dur)
+        rsp_label = f"resp tag={tag} src={dst} dst={src} w={write}"
+        emit_token(
+            lines,
+            f"rsp_{idx}",
+            rsp_coords,
+            rsp_begin,
+            rsp_dur,
+            "#22c55e",
+            "diamond",
+            rsp_label,
+        )
+
+    lines.append("</svg>")
+    out_path.write_text("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render animated SVG for TMU ring flows.")
+    parser.add_argument("csv", type=Path, help="Path to tmu_trace.csv")
+    parser.add_argument("-o", "--out", type=Path, default=Path("tmu_flow.svg"), help="Output SVG")
+    parser.add_argument("--cycle", type=float, default=0.06, help="Seconds per cycle")
+    args = parser.parse_args()
+
+    transactions, max_cycle = load_transactions(args.csv)
+    if not transactions:
+        raise SystemExit("no transactions found in CSV")
+    render_svg(transactions, max_cycle, args.out, args.cycle)
+
+
+if __name__ == "__main__":
+    main()

--- a/janus/tools/plot_tmu_trace.py
+++ b/janus/tools/plot_tmu_trace.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+from pathlib import Path
+
+
+def load_events(path: Path):
+    events = []
+    max_cycle = 0
+    max_node = 0
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                cycle = int(row.get("cycle", "0"))
+                node = int(row.get("node", "0"))
+            except ValueError:
+                continue
+            event = row.get("event", "")
+            tag = row.get("tag", "")
+            write = row.get("write", "")
+            events.append((cycle, node, event, tag, write))
+            if cycle > max_cycle:
+                max_cycle = cycle
+            if node > max_node:
+                max_node = node
+    return events, max_cycle, max_node
+
+
+def render_svg(events, max_cycle, max_node, scale, lane_h, out_path: Path):
+    margin_x = 70
+    margin_top = 60
+    margin_bottom = 30
+    width = margin_x * 2 + max_cycle * scale + 1
+    height = margin_top + margin_bottom + (max_node + 1) * lane_h
+
+    def y_for(node, event):
+        base = margin_top + node * lane_h
+        if event == "resp":
+            return base + int(lane_h * 0.68)
+        return base + int(lane_h * 0.28)
+
+    lines = []
+    lines.append(
+        f"<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}'>"
+    )
+    lines.append("<rect x='0' y='0' width='100%' height='100%' fill='#f9fafb' />")
+    lines.append(
+        "<style>"
+        "text{font-family:monospace;font-size:12px;fill:#111827;}"
+        ".grid{stroke:#e5e7eb;stroke-width:1;}"
+        ".lane{fill:#ffffff;}"
+        ".lane-alt{fill:#f3f4f6;}"
+        ".mid{stroke:#d1d5db;stroke-dasharray:2 3;}"
+        ".label{fill:#111827;font-size:12px;}"
+        ".title{font-size:14px;font-weight:bold;}"
+        ".legend{font-size:11px;fill:#374151;}"
+        "</style>"
+    )
+
+    lines.append(
+        f"<text class='title' x='{margin_x}' y='{margin_top - 30}'>TMU trace timeline</text>"
+    )
+    lines.append(
+        f"<text class='legend' x='{margin_x}' y='{margin_top - 12}'>accept = blue circle, resp = green diamond</text>"
+    )
+
+    if max_cycle <= 50:
+        tick_step = 5
+    elif max_cycle <= 200:
+        tick_step = 10
+    elif max_cycle <= 500:
+        tick_step = 20
+    else:
+        tick_step = 50
+
+    for n in range(max_node + 1):
+        y = margin_top + n * lane_h
+        lane_cls = "lane" if (n % 2 == 0) else "lane-alt"
+        lines.append(
+            f"<rect class='{lane_cls}' x='{margin_x}' y='{y}' width='{width - margin_x * 2}' height='{lane_h}' />"
+        )
+        mid_y = y + int(lane_h * 0.5)
+        lines.append(f"<line class='mid' x1='{margin_x}' y1='{mid_y}' x2='{width - margin_x}' y2='{mid_y}' />")
+        lines.append(f"<text class='label' x='8' y='{y + 14}'>node{n}</text>")
+
+    for cyc in range(0, max_cycle + 1, tick_step):
+        x = margin_x + cyc * scale
+        lines.append(f"<line class='grid' x1='{x}' y1='{margin_top}' x2='{x}' y2='{height - margin_bottom}' />")
+        lines.append(f"<text class='legend' x='{x + 2}' y='{height - 8}'>{cyc}</text>")
+
+    for cycle, node, event, tag, write in events:
+        x = margin_x + cycle * scale
+        y = y_for(node, event)
+        is_accept = event == "accept"
+        color = "#2563eb" if is_accept else "#16a34a"
+        label = f"{event} node={node} tag={tag} w={write} cycle={cycle}"
+        if is_accept:
+            lines.append(f"<circle cx='{x}' cy='{y}' r='3.5' fill='{color}' stroke='#1e3a8a' stroke-width='0.5'>")
+            lines.append(f"<title>{label}</title>")
+            lines.append("</circle>")
+        else:
+            size = 4
+            points = [
+                f"{x},{y - size}",
+                f"{x + size},{y}",
+                f"{x},{y + size}",
+                f"{x - size},{y}",
+            ]
+            lines.append(
+                f"<polygon points='{' '.join(points)}' fill='{color}' stroke='#14532d' stroke-width='0.5'>"
+            )
+            lines.append(f"<title>{label}</title>")
+            lines.append("</polygon>")
+
+    lines.append("</svg>")
+    out_path.write_text("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render TMU trace CSV into SVG timeline.")
+    parser.add_argument("csv", type=Path, help="Path to tmu_trace.csv")
+    parser.add_argument("-o", "--out", type=Path, default=Path("tmu_trace.svg"), help="Output SVG path")
+    parser.add_argument("--scale", type=int, default=4, help="Pixels per cycle")
+    parser.add_argument("--lane", type=int, default=30, help="Pixels per node lane")
+    args = parser.parse_args()
+
+    events, max_cycle, max_node = load_events(args.csv)
+    if not events:
+        raise SystemExit("no events found in CSV")
+    events.sort(key=lambda e: (e[0], e[1], 0 if e[2] == "accept" else 1))
+    render_svg(events, max_cycle, max_node, args.scale, args.lane, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/janus/tools/run_janus_tmu_pyc_cpp.sh
+++ b/janus/tools/run_janus_tmu_pyc_cpp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/lib.sh
+source "${ROOT_DIR}/scripts/lib.sh"
+pyc_find_pyc_compile
+
+GEN_DIR="${ROOT_DIR}/janus/generated/janus_tmu_pyc"
+HDR="${GEN_DIR}/janus_tmu_pyc_gen.hpp"
+
+need_regen=0
+if [[ ! -f "${HDR}" ]]; then
+  need_regen=1
+elif find "${ROOT_DIR}/janus/pyc/janus/tmu" -name '*.py' -newer "${HDR}" | grep -q .; then
+  need_regen=1
+fi
+
+if [[ "${need_regen}" -ne 0 ]]; then
+  bash "${ROOT_DIR}/janus/tools/update_tmu_generated.sh"
+fi
+
+WORK_DIR="$(mktemp -d -t janus_tmu_pyc_tb.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+"${CXX:-clang++}" -std=c++17 -O2 \
+  -I "${ROOT_DIR}/include" \
+  -I "${GEN_DIR}" \
+  -o "${WORK_DIR}/tb_janus_tmu_pyc" \
+  "${ROOT_DIR}/janus/tb/tb_janus_tmu_pyc.cpp"
+
+if [[ $# -gt 0 ]]; then
+  "${WORK_DIR}/tb_janus_tmu_pyc" "$@"
+else
+  "${WORK_DIR}/tb_janus_tmu_pyc"
+fi

--- a/janus/tools/run_janus_tmu_pyc_verilator.sh
+++ b/janus/tools/run_janus_tmu_pyc_verilator.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/lib.sh
+source "${ROOT_DIR}/scripts/lib.sh"
+pyc_find_pyc_compile
+
+VERILATOR="${VERILATOR:-$(command -v verilator || true)}"
+if [[ -z "${VERILATOR}" ]]; then
+  echo "error: missing verilator (install with: brew install verilator)" >&2
+  exit 1
+fi
+
+GEN_DIR="${ROOT_DIR}/janus/generated/janus_tmu_pyc"
+VLOG="${GEN_DIR}/janus_tmu_pyc.v"
+if [[ ! -f "${VLOG}" ]]; then
+  bash "${ROOT_DIR}/janus/tools/update_tmu_generated.sh"
+fi
+
+TB_SV="${ROOT_DIR}/janus/tb/tb_janus_tmu_pyc.sv"
+OBJ_DIR="${GEN_DIR}/verilator_obj"
+EXE="${OBJ_DIR}/Vtb_janus_tmu_pyc"
+
+need_build=0
+if [[ ! -x "${EXE}" ]]; then
+  need_build=1
+elif [[ "${TB_SV}" -nt "${EXE}" || "${VLOG}" -nt "${EXE}" ]]; then
+  need_build=1
+fi
+
+if [[ "${need_build}" -ne 0 ]]; then
+  mkdir -p "${OBJ_DIR}"
+  "${VERILATOR}" \
+    --binary \
+    --timing \
+    --trace \
+    -Wno-fatal \
+    -I"${ROOT_DIR}/include/pyc/verilog" \
+    --top-module tb_janus_tmu_pyc \
+    "${TB_SV}" \
+    "${VLOG}" \
+    --Mdir "${OBJ_DIR}"
+fi
+
+echo "[janus-vlt] tmu"
+"${EXE}" "$@"

--- a/janus/tools/update_tmu_generated.sh
+++ b/janus/tools/update_tmu_generated.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=../../scripts/lib.sh
+source "${ROOT_DIR}/scripts/lib.sh"
+pyc_find_pyc_compile
+
+OUT_ROOT="${ROOT_DIR}/janus/generated/janus_tmu_pyc"
+mkdir -p "${OUT_ROOT}"
+
+tmp_pyc="$(mktemp -t "pycircuit.janus.tmu.XXXXXX.pyc")"
+
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$(pyc_pythonpath):${ROOT_DIR}/janus/pyc" \
+  python3 -m pycircuit.cli emit "${ROOT_DIR}/janus/pyc/janus/tmu/janus_tmu_pyc.py" -o "${tmp_pyc}"
+
+"${PYC_COMPILE}" "${tmp_pyc}" --emit=verilog -o "${OUT_ROOT}/janus_tmu_pyc.v"
+"${PYC_COMPILE}" "${tmp_pyc}" --emit=cpp -o "${OUT_ROOT}/janus_tmu_pyc.hpp"
+
+mv -f "${OUT_ROOT}/janus_tmu_pyc.hpp" "${OUT_ROOT}/janus_tmu_pyc_gen.hpp"
+
+pyc_log "ok: wrote TMU outputs under ${OUT_ROOT}"


### PR DESCRIPTION
## 概述

添加 Janus TMU (Tile Management Unit) 的 RTL 实现、测试平台和架构规格书。

## 变更内容

### TMU RTL 实现
- `janus/pyc/janus/tmu/janus_tmu_pyc.py`: 基于 pyCircuit DSL 的 TMU 完整实现
  - 8 站点双向 Ring 互联 (CW/CC)
  - 静态最短路径路由，编译时预计算路由表
  - SPB (Send/Post Buffer): depth=4, 1W2R, 不支持 bypass
  - MGB (Merge Buffer): depth=4, 2W1R, 支持 bypass + RR 仲裁
  - 可配置 TileReg (默认 1MB, 8 pipe x 128KB SRAM)
  - 地址编码: [19:11] index | [10:8] pipe | [7:0] offset
  - 峰值带宽: 256B × 8 / cycle

### 测试平台
- `janus/tb/tb_janus_tmu_pyc.cpp`: C++ cycle-accurate 测试
- `janus/tb/tb_janus_tmu_pyc.sv`: SystemVerilog 测试
- 测试覆盖:
  - 每个 node 本地读写 (node_i → pipe_i)
  - 跨节点读写 (node0 → pipe2)
  - Ring 流量测试 (每个 node 访问非本地 pipe)

### 架构文档
- `janus/docs/TMU_SPEC.md`: 17 章完整规格书，涵盖拓扑、Flit 格式、时序分析、反压机制、防活锁策略等

## 延迟模型

`Latency = 4 + 2 × H` cycles (H = Ring 跳数, 无竞争)

| 访问类型 | 延迟 |
|---------|------|
| 本地 (H=0) | 4 cycles |
| 相邻 (H=1) | 6 cycles |
| 最远 (H=4) | 12 cycles |