### PR TITLE
Port Verilog design to pyCircuit (traffic lights + dodgeball game)

### DIFF
--- a/examples/dodgeball_game/README.md
+++ b/examples/dodgeball_game/README.md
@@ -1,0 +1,66 @@
+# Dodgeball Game (pyCircuit)
+
+A cycle-aware rewrite of the dodgeball VGA demo. The design keeps the original
+FSM and object motion timing while adding `left/right` movement for the player.
+The terminal emulator renders a downsampled VGA view to keep runtime low.
+
+**Key files**
+- `lab_final_top.py`: pyCircuit top-level (game FSM, objects, player, VGA colors).
+- `lab_final_VGA.py`: VGA timing generator (640x480 @ 60Hz).
+- `dodgeball_capi.cpp`: C API wrapper for ctypes simulation.
+- `emulate_dodgeball.py`: terminal visualization + optional auto-build.
+- `stimuli/basic.py`: external stimulus for `START/left/right/RST_BTN`.
+
+## Ports
+
+| Port | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | System clock |
+| `rst` | in | 1 | Synchronous reset (for deterministic init) |
+| `RST_BTN` | in | 1 | Game reset input (matches reference behavior) |
+| `START` | in | 1 | Start game |
+| `left` | in | 1 | Move player left (game tick) |
+| `right` | in | 1 | Move player right (game tick) |
+| `VGA_HS_O` | out | 1 | VGA HSync |
+| `VGA_VS_O` | out | 1 | VGA VSync |
+| `VGA_R` | out | 4 | VGA red (MSB used) |
+| `VGA_G` | out | 4 | VGA green (MSB used) |
+| `VGA_B` | out | 4 | VGA blue (MSB used) |
+| `dbg_state` | out | 3 | FSM state (0 init, 1 play, 2 over) |
+| `dbg_j` | out | 5 | Object step counter |
+| `dbg_player_x` | out | 4 | Player column (0-15) |
+| `dbg_ob*_x/y` | out | 4 | Object positions |
+
+## Run (Auto-Build)
+
+The emulator will build the C++ simulation library if it is missing. Use
+`--rebuild` to force regeneration.
+
+```bash
+python3 examples/dodgeball_game/emulate_dodgeball.py
+python3 examples/dodgeball_game/emulate_dodgeball.py --rebuild
+```
+
+## Manual Build and Run
+
+```bash
+PYTHONPATH=python:. python3 -m pycircuit.cli emit \
+  examples/dodgeball_game/lab_final_top.py \
+  -o examples/generated/dodgeball_game/dodgeball_game.pyc
+
+./build/bin/pyc-compile examples/generated/dodgeball_game/dodgeball_game.pyc \
+  --emit=cpp --out-dir=examples/generated/dodgeball_game
+
+c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
+  -o examples/dodgeball_game/libdodgeball_sim.dylib \
+  examples/dodgeball_game/dodgeball_capi.cpp
+
+python3 examples/dodgeball_game/emulate_dodgeball.py --stim basic
+```
+
+## Stimuli
+
+Stimulus is separated from the DUT and loaded as a module.
+Available modules live under `examples/dodgeball_game/stimuli/`.
+
+- `basic`: start, move left, then move right, plus a reset/restart sequence.

--- a/examples/dodgeball_game/__init__.py
+++ b/examples/dodgeball_game/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for dodgeball_game example.

--- a/examples/dodgeball_game/dodgeball_capi.cpp
+++ b/examples/dodgeball_game/dodgeball_capi.cpp
@@ -1,0 +1,82 @@
+/**
+ * dodgeball_capi.cpp — C API wrapper around the generated RTL model.
+ *
+ * Build:
+ *   cd <pyCircuit root>
+ *   c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
+ *       -o examples/dodgeball_game/libdodgeball_sim.dylib \
+ *       examples/dodgeball_game/dodgeball_capi.cpp
+ */
+
+#include <cstdint>
+#include <pyc/cpp/pyc_sim.hpp>
+#include <pyc/cpp/pyc_tb.hpp>
+
+#include "../generated/dodgeball_game/dodgeball_game.hpp"
+
+using pyc::cpp::Wire;
+
+struct SimContext {
+    pyc::gen::dodgeball_game dut{};
+    pyc::cpp::Testbench<pyc::gen::dodgeball_game> tb;
+    uint64_t cycle = 0;
+
+    SimContext() : tb(dut) {
+        tb.addClock(dut.clk, /*halfPeriodSteps=*/1);
+    }
+};
+
+extern "C" {
+
+SimContext* db_create() {
+    return new SimContext();
+}
+
+void db_destroy(SimContext* ctx) {
+    delete ctx;
+}
+
+void db_reset(SimContext* ctx, uint64_t cycles) {
+    ctx->tb.reset(ctx->dut.rst, /*cyclesAsserted=*/cycles, /*cyclesDeasserted=*/1);
+    ctx->dut.eval();
+    ctx->cycle = 0;
+}
+
+void db_set_inputs(SimContext* ctx, int rst_btn, int start, int left, int right) {
+    ctx->dut.RST_BTN = Wire<1>(rst_btn ? 1u : 0u);
+    ctx->dut.START   = Wire<1>(start ? 1u : 0u);
+    ctx->dut.left    = Wire<1>(left ? 1u : 0u);
+    ctx->dut.right   = Wire<1>(right ? 1u : 0u);
+}
+
+void db_tick(SimContext* ctx) {
+    ctx->tb.runCycles(1);
+    ctx->cycle++;
+}
+
+void db_run_cycles(SimContext* ctx, uint64_t n) {
+    ctx->tb.runCycles(n);
+    ctx->cycle += n;
+}
+
+// VGA outputs
+uint32_t db_get_vga_hs(SimContext* ctx) { return ctx->dut.VGA_HS_O.value(); }
+uint32_t db_get_vga_vs(SimContext* ctx) { return ctx->dut.VGA_VS_O.value(); }
+uint32_t db_get_vga_r(SimContext* ctx)  { return ctx->dut.VGA_R.value(); }
+uint32_t db_get_vga_g(SimContext* ctx)  { return ctx->dut.VGA_G.value(); }
+uint32_t db_get_vga_b(SimContext* ctx)  { return ctx->dut.VGA_B.value(); }
+
+// Debug outputs
+uint32_t db_get_state(SimContext* ctx)     { return ctx->dut.dbg_state.value(); }
+uint32_t db_get_j(SimContext* ctx)         { return ctx->dut.dbg_j.value(); }
+uint32_t db_get_player_x(SimContext* ctx)  { return ctx->dut.dbg_player_x.value(); }
+uint32_t db_get_ob1_x(SimContext* ctx)     { return ctx->dut.dbg_ob1_x.value(); }
+uint32_t db_get_ob1_y(SimContext* ctx)     { return ctx->dut.dbg_ob1_y.value(); }
+uint32_t db_get_ob2_x(SimContext* ctx)     { return ctx->dut.dbg_ob2_x.value(); }
+uint32_t db_get_ob2_y(SimContext* ctx)     { return ctx->dut.dbg_ob2_y.value(); }
+uint32_t db_get_ob3_x(SimContext* ctx)     { return ctx->dut.dbg_ob3_x.value(); }
+uint32_t db_get_ob3_y(SimContext* ctx)     { return ctx->dut.dbg_ob3_y.value(); }
+
+uint64_t db_get_cycle(SimContext* ctx) { return ctx->cycle; }
+
+} // extern "C"

--- a/examples/dodgeball_game/emulate_dodgeball.py
+++ b/examples/dodgeball_game/emulate_dodgeball.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+emulate_dodgeball.py — True RTL simulation of the dodgeball game
+with a terminal visualization.
+
+By default the script will build the C++ simulation library if missing.
+Use --rebuild to force regeneration.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# =============================================================================
+# ANSI helpers
+# =============================================================================
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+CYAN = "\033[36m"
+WHITE = "\033[37m"
+
+
+def clear_screen() -> None:
+    print("\033[2J\033[H", end="")
+
+
+# =============================================================================
+# RTL simulation wrapper (ctypes -> compiled C++ netlist)
+# =============================================================================
+
+MAIN_CLK_BIT = 20
+CYCLES_PER_TICK = 1 << (MAIN_CLK_BIT + 1)
+
+
+class DodgeballRTL:
+    def __init__(self, lib_path: str | None = None):
+        if lib_path is None:
+            lib_path = str(Path(__file__).resolve().parent / "libdodgeball_sim.dylib")
+        self._lib = ctypes.CDLL(lib_path)
+
+        self._lib.db_create.restype = ctypes.c_void_p
+        self._lib.db_destroy.argtypes = [ctypes.c_void_p]
+        self._lib.db_reset.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        self._lib.db_set_inputs.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+        self._lib.db_tick.argtypes = [ctypes.c_void_p]
+        self._lib.db_run_cycles.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+
+        for name in (
+            "db_get_state", "db_get_j", "db_get_player_x",
+            "db_get_ob1_x", "db_get_ob1_y",
+            "db_get_ob2_x", "db_get_ob2_y",
+            "db_get_ob3_x", "db_get_ob3_y",
+            "db_get_vga_hs", "db_get_vga_vs",
+            "db_get_vga_r", "db_get_vga_g", "db_get_vga_b",
+        ):
+            getattr(self._lib, name).argtypes = [ctypes.c_void_p]
+            getattr(self._lib, name).restype = ctypes.c_uint32
+
+        self._lib.db_get_cycle.argtypes = [ctypes.c_void_p]
+        self._lib.db_get_cycle.restype = ctypes.c_uint64
+
+        self._ctx = self._lib.db_create()
+        self.rst_btn = 0
+        self.start = 0
+        self.left = 0
+        self.right = 0
+
+    def __del__(self):
+        if hasattr(self, "_ctx") and self._ctx:
+            self._lib.db_destroy(self._ctx)
+
+    def reset(self, cycles: int = 2):
+        self._lib.db_reset(self._ctx, cycles)
+
+    def _apply_inputs(self):
+        self._lib.db_set_inputs(self._ctx, self.rst_btn, self.start, self.left, self.right)
+
+    def tick(self):
+        self._apply_inputs()
+        self._lib.db_tick(self._ctx)
+
+    def run_cycles(self, n: int):
+        self._apply_inputs()
+        self._lib.db_run_cycles(self._ctx, n)
+
+    @property
+    def state(self) -> int:
+        return int(self._lib.db_get_state(self._ctx))
+
+    @property
+    def j(self) -> int:
+        return int(self._lib.db_get_j(self._ctx))
+
+    @property
+    def player_x(self) -> int:
+        return int(self._lib.db_get_player_x(self._ctx))
+
+    @property
+    def ob1(self) -> tuple[int, int]:
+        return (int(self._lib.db_get_ob1_x(self._ctx)), int(self._lib.db_get_ob1_y(self._ctx)))
+
+    @property
+    def ob2(self) -> tuple[int, int]:
+        return (int(self._lib.db_get_ob2_x(self._ctx)), int(self._lib.db_get_ob2_y(self._ctx)))
+
+    @property
+    def ob3(self) -> tuple[int, int]:
+        return (int(self._lib.db_get_ob3_x(self._ctx)), int(self._lib.db_get_ob3_y(self._ctx)))
+
+    @property
+    def cycle(self) -> int:
+        return int(self._lib.db_get_cycle(self._ctx))
+
+
+# =============================================================================
+# Build helpers
+# =============================================================================
+
+
+def _find_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _find_pyc_compile(root: Path) -> Path:
+    candidates = [
+        root / "build-top" / "bin" / "pyc-compile",
+        root / "build" / "bin" / "pyc-compile",
+        root / "pyc" / "mlir" / "build" / "bin" / "pyc-compile",
+    ]
+    for c in candidates:
+        if c.is_file() and os.access(c, os.X_OK):
+            return c
+    found = shutil.which("pyc-compile")
+    if found:
+        return Path(found)
+    raise RuntimeError("missing pyc-compile (build it with: scripts/pyc build)")
+
+
+def _ensure_built(force: bool = False) -> None:
+    root = _find_root()
+    lib_path = Path(__file__).resolve().parent / "libdodgeball_sim.dylib"
+    srcs = [
+        root / "examples" / "dodgeball_game" / "lab_final_top.py",
+        root / "examples" / "dodgeball_game" / "lab_final_VGA.py",
+        root / "examples" / "dodgeball_game" / "dodgeball_capi.cpp",
+    ]
+    if lib_path.exists() and not force:
+        lib_mtime = lib_path.stat().st_mtime
+        if all(s.exists() and s.stat().st_mtime <= lib_mtime for s in srcs):
+            return
+
+    gen_dir = root / "examples" / "generated" / "dodgeball_game"
+    gen_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    py_path = f"{root}/python:{root}"
+    if env.get("PYTHONPATH"):
+        py_path = f"{py_path}:{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = py_path
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pycircuit.cli",
+            "emit",
+            "examples/dodgeball_game/lab_final_top.py",
+            "-o",
+            str(gen_dir / "dodgeball_game.pyc"),
+        ],
+        cwd=root,
+        env=env,
+        check=True,
+    )
+
+    pyc_compile = _find_pyc_compile(root)
+    subprocess.run(
+        [
+            str(pyc_compile),
+            str(gen_dir / "dodgeball_game.pyc"),
+            "--emit=cpp",
+            f"--out-dir={gen_dir}",
+        ],
+        cwd=root,
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "c++",
+            "-std=c++17",
+            "-O2",
+            "-shared",
+            "-fPIC",
+            "-I",
+            "include",
+            "-I",
+            ".",
+            "-o",
+            str(lib_path),
+            "examples/dodgeball_game/dodgeball_capi.cpp",
+        ],
+        cwd=root,
+        check=True,
+    )
+
+
+# =============================================================================
+# Rendering (downsampled VGA)
+# =============================================================================
+
+ACTIVE_W = 640
+ACTIVE_H = 480
+SCALE_X = 40
+SCALE_Y = 40
+GRID_W = ACTIVE_W // SCALE_X
+GRID_H = ACTIVE_H // SCALE_Y
+
+_COLOR = {
+    (0, 0, 0): f"{DIM}.{RESET}",
+    (1, 0, 0): f"{RED}#{RESET}",
+    (0, 1, 0): f"{GREEN}#{RESET}",
+    (0, 0, 1): f"{BLUE}#{RESET}",
+    (1, 1, 0): f"{YELLOW}#{RESET}",
+    (1, 0, 1): f"{RED}#{RESET}",
+    (0, 1, 1): f"{CYAN}#{RESET}",
+    (1, 1, 1): f"{WHITE}#{RESET}",
+}
+
+STATE_NAMES = {
+    0: "INIT",
+    1: "PLAY",
+    2: "OVER",
+}
+
+
+def _vga_color_at(
+    x: int,
+    y: int,
+    *,
+    state: int,
+    player_x: int,
+    objects: list[tuple[int, int]],
+) -> tuple[int, int, int]:
+    def in_range(v: int, lo: int, hi: int) -> bool:
+        return (v > lo) and (v < hi)
+
+    sq_player = (
+        in_range(x, 40 * player_x, 40 * (player_x + 1)) and
+        in_range(y, 400, 440)
+    )
+
+    def sq_object(ox: int, oy: int) -> bool:
+        return (
+            in_range(x, 40 * ox, 40 * (ox + 1)) and
+            in_range(y, 40 * oy, 40 * (oy + 1))
+        )
+
+    sq_obj1 = sq_object(*objects[0])
+    sq_obj2 = sq_object(*objects[1])
+    sq_obj3 = sq_object(*objects[2])
+
+    over_wire = in_range(x, 0, 640) and in_range(y, 0, 480)
+    down = in_range(x, 0, 640) and in_range(y, 440, 480)
+    up = in_range(x, 0, 640) and in_range(y, 0, 40)
+
+    over = (state == 2)
+    not_over = not over
+
+    r = 1 if (sq_player and not_over) else 0
+    b = 1 if ((sq_obj1 or sq_obj2 or sq_obj3 or down or up) and not_over) else 0
+    g = 1 if (over_wire and over) else 0
+    return (r, g, b)
+
+
+def render_vga_sampled(state: int, player_x: int, objects: list[tuple[int, int]]) -> list[str]:
+    lines: list[str] = []
+    for row in range(GRID_H):
+        y = row * SCALE_Y + (SCALE_Y // 2)
+        line = []
+        for col in range(GRID_W):
+            x = col * SCALE_X + (SCALE_X // 2)
+            rgb = _vga_color_at(x, y, state=state, player_x=player_x, objects=objects)
+            line.append(_COLOR.get(rgb, _COLOR[(0, 0, 0)]))
+        lines.append("".join(line))
+    return lines
+
+
+# =============================================================================
+# Stimulus loading
+# =============================================================================
+
+
+def _load_stimulus(name: str):
+    if "." in name:
+        return importlib.import_module(name)
+    try:
+        return importlib.import_module(f"examples.dodgeball_game.stimuli.{name}")
+    except ModuleNotFoundError:
+        root = _find_root()
+        sys.path.insert(0, str(root))
+        return importlib.import_module(f"examples.dodgeball_game.stimuli.{name}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Dodgeball terminal emulator")
+    ap.add_argument(
+        "--stim",
+        default="basic",
+        help="Stimulus module name (e.g. basic)",
+    )
+    ap.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force rebuild of the C++ simulation library",
+    )
+    args = ap.parse_args()
+
+    _ensure_built(force=args.rebuild)
+
+    stim = _load_stimulus(args.stim)
+
+    rtl = DodgeballRTL()
+    rtl.reset()
+    if hasattr(stim, "init"):
+        stim.init(rtl)
+
+    total_ticks = int(getattr(stim, "total_ticks", lambda: 20)())
+    frame_sleep = float(getattr(stim, "sleep_s", lambda: 0.08)())
+
+    for tick in range(total_ticks):
+        if hasattr(stim, "step"):
+            stim.step(tick, rtl)
+        rtl.run_cycles(CYCLES_PER_TICK)
+
+        clear_screen()
+
+        state_name = STATE_NAMES.get(rtl.state, f"S{rtl.state}")
+        objs = [rtl.ob1, rtl.ob2, rtl.ob3]
+        grid_lines = render_vga_sampled(rtl.state, rtl.player_x, objs)
+
+        print(f"{BOLD}{CYAN}dodgeball_game{RESET}  tick={tick}")
+        print(f"cycle={rtl.cycle}  state={state_name}  j={rtl.j}  main_clk_bit={MAIN_CLK_BIT}")
+        print(f"RST_BTN={rtl.rst_btn}  START={rtl.start}  left={rtl.left}  right={rtl.right}")
+        print(f"note: VGA shown with {GRID_W}x{GRID_H} downsample")
+        print("")
+        for line in grid_lines:
+            print(line)
+
+        time.sleep(frame_sleep)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dodgeball_game/lab_final_VGA.py
+++ b/examples/dodgeball_game/lab_final_VGA.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""VGA timing generator — pyCircuit cycle-aware rewrite of lab_final_VGA.v.
+
+Implements the same 640x480@60Hz timing logic with 800x524 total counts.
+"""
+from __future__ import annotations
+
+from pycircuit import (
+    CycleAwareCircuit,
+    CycleAwareDomain,
+    compile_cycle_aware,
+    mux,
+)
+
+# VGA timing constants (same as reference Verilog)
+HS_STA = 16
+HS_END = 16 + 96
+HA_STA = 16 + 96 + 48
+VS_STA = 480 + 11
+VS_END = 480 + 11 + 2
+VA_END = 480
+LINE = 800
+SCREEN = 524
+
+
+def vga_timing(domain: CycleAwareDomain, i_pix_stb):
+    """Build VGA timing logic.
+
+    Returns a tuple containing internal regs, next-state signals, and outputs
+    so callers can update all flops after a shared domain.next().
+    """
+    c = lambda v, w: domain.const(v, width=w)
+
+    h_count = domain.signal("vga_h_count", width=10, reset=0)
+    v_count = domain.signal("vga_v_count", width=10, reset=0)
+
+    h_end = h_count.eq(c(LINE, 10))
+    v_end = v_count.eq(c(SCREEN, 10))
+
+    h_inc = h_count + c(1, 10)
+    v_inc = v_count + c(1, 10)
+
+    h_after = mux(h_end, c(0, 10), h_inc)
+    v_after = mux(h_end, v_inc, v_count)
+    v_after = mux(v_end, c(0, 10), v_after)
+
+    h_next = mux(i_pix_stb, h_after, h_count)
+    v_next = mux(i_pix_stb, v_after, v_count)
+
+    o_hs = ~(h_count.ge(c(HS_STA, 10)) & h_count.lt(c(HS_END, 10)))
+    o_vs = ~(v_count.ge(c(VS_STA, 10)) & v_count.lt(c(VS_END, 10)))
+
+    o_x = mux(h_count.lt(c(HA_STA, 10)), c(0, 10), h_count - c(HA_STA, 10))
+    y_full = mux(v_count.ge(c(VA_END, 10)), c(VA_END - 1, 10), v_count)
+    o_y = y_full.trunc(width=9)
+
+    o_blanking = h_count.lt(c(HA_STA, 10)) | v_count.gt(c(VA_END - 1, 10))
+    o_animate = v_count.eq(c(VA_END - 1, 10)) & h_count.eq(c(LINE, 10))
+
+    return (
+        h_count,
+        v_count,
+        h_next,
+        v_next,
+        o_hs,
+        o_vs,
+        o_blanking,
+        o_animate,
+        o_x,
+        o_y,
+    )
+
+
+def _lab_final_vga_impl(m: CycleAwareCircuit, domain: CycleAwareDomain) -> None:
+    """Standalone VGA module (ports mirror the reference Verilog)."""
+    i_pix_stb = domain.input("i_pix_stb", width=1)
+
+    (
+        h_count,
+        v_count,
+        h_next,
+        v_next,
+        o_hs,
+        o_vs,
+        o_blanking,
+        o_animate,
+        o_x,
+        o_y,
+    ) = vga_timing(domain, i_pix_stb)
+
+    # DFF boundary
+    domain.next()
+
+    # Flop updates
+    h_count.set(h_next)
+    v_count.set(v_next)
+
+    # Outputs
+    m.output("o_hs", o_hs)
+    m.output("o_vs", o_vs)
+    m.output("o_blanking", o_blanking)
+    m.output("o_animate", o_animate)
+    m.output("o_x", o_x)
+    m.output("o_y", o_y)
+
+
+def lab_final_vga(m: CycleAwareCircuit, domain: CycleAwareDomain) -> None:
+    _lab_final_vga_impl(m, domain)
+
+
+def build():
+    return compile_cycle_aware(lab_final_vga, name="lab_final_vga")
+
+
+if __name__ == "__main__":
+    circuit = build()
+    print(circuit.emit_mlir())

--- a/examples/dodgeball_game/lab_final_top.py
+++ b/examples/dodgeball_game/lab_final_top.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""Dodgeball top — pyCircuit cycle-aware rewrite of lab_final_top.v.
+
+Notes:
+- `clk` corresponds to the original `CLK_in`.
+- A synchronous `rst` port is introduced for deterministic initialization.
+- The internal game logic still uses `RST_BTN` exactly like the reference.
+"""
+from __future__ import annotations
+
+from pycircuit import (
+    CycleAwareCircuit,
+    CycleAwareDomain,
+    compile_cycle_aware,
+    mux,
+    ca_cat,
+)
+
+try:
+    from .lab_final_VGA import vga_timing
+except ImportError:
+    import sys
+    from pathlib import Path
+    _ROOT = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(_ROOT))
+    from examples.dodgeball_game.lab_final_VGA import vga_timing
+
+
+def _dodgeball_impl(
+    m: CycleAwareCircuit,
+    domain: CycleAwareDomain,
+    *,
+    MAIN_CLK_BIT: int = 20,
+) -> None:
+    if MAIN_CLK_BIT < 0 or MAIN_CLK_BIT > 24:
+        raise ValueError("MAIN_CLK_BIT must be in [0, 24]")
+
+    c = lambda v, w: domain.const(v, width=w)
+
+    # ================================================================
+    # Inputs
+    # ================================================================
+    rst_btn = domain.input("RST_BTN", width=1)
+    start = domain.input("START", width=1)
+    left = domain.input("left", width=1)
+    right = domain.input("right", width=1)
+
+    # (left/right are unused in the reference logic, but kept as ports.)
+    _ = left
+    _ = right
+
+    # ================================================================
+    # Flops (Q outputs at cycle 0)
+    # ================================================================
+    cnt = domain.signal("pix_cnt", width=16, reset=0)
+    pix_stb = domain.signal("pix_stb", width=1, reset=0)
+    main_clk = domain.signal("main_clk", width=25, reset=0)
+
+    player_x = domain.signal("player_x", width=4, reset=8)
+    j = domain.signal("j", width=5, reset=0)
+
+    ob1_x = domain.signal("ob1_x", width=4, reset=1)
+    ob2_x = domain.signal("ob2_x", width=4, reset=4)
+    ob3_x = domain.signal("ob3_x", width=4, reset=7)
+
+    ob1_y = domain.signal("ob1_y", width=4, reset=0)
+    ob2_y = domain.signal("ob2_y", width=4, reset=0)
+    ob3_y = domain.signal("ob3_y", width=4, reset=0)
+
+    fsm_state = domain.signal("fsm_state", width=3, reset=0)
+
+    # ================================================================
+    # Combinational logic (cycle 0)
+    # ================================================================
+
+    # --- Pixel strobe divider ---
+    cnt_ext = cnt.zext(width=17)
+    sum17 = cnt_ext + c(0x4000, 17)
+    cnt_next = sum17.trunc(width=16)
+    pix_stb_next = sum17[16]
+
+    # --- Main clock divider bit (for game logic tick) ---
+    main_clk_next = main_clk + c(1, 25)
+    main_bit = main_clk[MAIN_CLK_BIT]
+    main_next_bit = main_clk_next[MAIN_CLK_BIT]
+    game_tick = (~main_bit) & main_next_bit
+
+    # --- VGA timing ---
+    (
+        vga_h_count,
+        vga_v_count,
+        vga_h_next,
+        vga_v_next,
+        vga_hs,
+        vga_vs,
+        vga_blanking,
+        vga_animate,
+        vga_x,
+        vga_y,
+    ) = vga_timing(domain, pix_stb)
+    _ = vga_blanking
+    _ = vga_animate
+
+    x = vga_x
+    y = vga_y
+
+    # --- Collision detection ---
+    collision = (
+        (ob1_x.eq(player_x) & ob1_y.eq(c(10, 4))) |
+        (ob2_x.eq(player_x) & ob2_y.eq(c(10, 4))) |
+        (ob3_x.eq(player_x) & ob3_y.eq(c(10, 4)))
+    )
+
+    # --- Object motion increments (boolean -> 4-bit) ---
+    inc1 = (j.gt(c(0, 5)) & j.lt(c(13, 5))).zext(width=4)
+    inc2 = (j.gt(c(3, 5)) & j.lt(c(16, 5))).zext(width=4)
+    inc3 = (j.gt(c(7, 5)) & j.lt(c(20, 5))).zext(width=4)
+
+    # --- FSM state flags ---
+    st0 = fsm_state.eq(c(0, 3))
+    st1 = fsm_state.eq(c(1, 3))
+    st2 = fsm_state.eq(c(2, 3))
+
+    cond_state0 = game_tick & st0
+    cond_state1 = game_tick & st1
+    cond_state2 = game_tick & st2
+
+    cond_start = cond_state0 & start
+    cond_rst_s1 = cond_state1 & rst_btn
+    cond_rst_s2 = cond_state2 & rst_btn
+    cond_collision = cond_state1 & collision
+    cond_j20 = cond_state1 & j.eq(c(20, 5))
+
+    # --- Player movement (left/right) ---
+    left_only = left & ~right
+    right_only = right & ~left
+    can_left = player_x.gt(c(0, 4))
+    can_right = player_x.lt(c(15, 4))
+    move_left = cond_state1 & left_only & can_left
+    move_right = cond_state1 & right_only & can_right
+
+    # --- VGA draw logic ---
+    x10 = x
+    y10 = y.zext(width=10)
+
+    player_x0 = player_x.zext(width=10) * c(40, 10)
+    player_x1 = (player_x + c(1, 4)).zext(width=10) * c(40, 10)
+
+    ob1_x0 = ob1_x.zext(width=10) * c(40, 10)
+    ob1_x1 = (ob1_x + c(1, 4)).zext(width=10) * c(40, 10)
+    ob1_y0 = ob1_y.zext(width=10) * c(40, 10)
+    ob1_y1 = (ob1_y + c(1, 4)).zext(width=10) * c(40, 10)
+
+    ob2_x0 = ob2_x.zext(width=10) * c(40, 10)
+    ob2_x1 = (ob2_x + c(1, 4)).zext(width=10) * c(40, 10)
+    ob2_y0 = ob2_y.zext(width=10) * c(40, 10)
+    ob2_y1 = (ob2_y + c(1, 4)).zext(width=10) * c(40, 10)
+
+    ob3_x0 = ob3_x.zext(width=10) * c(40, 10)
+    ob3_x1 = (ob3_x + c(1, 4)).zext(width=10) * c(40, 10)
+    ob3_y0 = ob3_y.zext(width=10) * c(40, 10)
+    ob3_y1 = (ob3_y + c(1, 4)).zext(width=10) * c(40, 10)
+
+    sq_player = (
+        x10.gt(player_x0) & y10.gt(c(400, 10)) &
+        x10.lt(player_x1) & y10.lt(c(440, 10))
+    )
+
+    sq_object1 = (
+        x10.gt(ob1_x0) & y10.gt(ob1_y0) &
+        x10.lt(ob1_x1) & y10.lt(ob1_y1)
+    )
+    sq_object2 = (
+        x10.gt(ob2_x0) & y10.gt(ob2_y0) &
+        x10.lt(ob2_x1) & y10.lt(ob2_y1)
+    )
+    sq_object3 = (
+        x10.gt(ob3_x0) & y10.gt(ob3_y0) &
+        x10.lt(ob3_x1) & y10.lt(ob3_y1)
+    )
+
+    over_wire = (
+        x10.gt(c(0, 10)) & y10.gt(c(0, 10)) &
+        x10.lt(c(640, 10)) & y10.lt(c(480, 10))
+    )
+    down = (
+        x10.gt(c(0, 10)) & y10.gt(c(440, 10)) &
+        x10.lt(c(640, 10)) & y10.lt(c(480, 10))
+    )
+    up = (
+        x10.gt(c(0, 10)) & y10.gt(c(0, 10)) &
+        x10.lt(c(640, 10)) & y10.lt(c(40, 10))
+    )
+
+    fsm_over = fsm_state.eq(c(2, 3))
+    not_over = ~fsm_over
+
+    circle = c(0, 1)
+
+    vga_r_bit = sq_player & not_over
+    vga_b_bit = (sq_object1 | sq_object2 | sq_object3 | down | up) & not_over
+    vga_g_bit = circle | (over_wire & fsm_over)
+
+    vga_r = ca_cat(vga_r_bit, c(0, 3))
+    vga_g = ca_cat(vga_g_bit, c(0, 3))
+    vga_b = ca_cat(vga_b_bit, c(0, 3))
+
+    # ================================================================
+    # DFF boundary
+    # ================================================================
+    domain.next()
+
+    # ================================================================
+    # Flop updates (last-write-wins order mirrors Verilog)
+    # ================================================================
+
+    # Clock divider flops
+    cnt.set(cnt_next)
+    pix_stb.set(pix_stb_next)
+    main_clk.set(main_clk_next)
+
+    # FSM state
+    fsm_state.set(1, when=cond_start)
+    fsm_state.set(0, when=cond_rst_s1)
+    fsm_state.set(2, when=cond_collision)
+    fsm_state.set(0, when=cond_rst_s2)
+
+    # j counter
+    j.set(0, when=cond_rst_s1)
+    j.set(0, when=cond_j20)
+    j.set(j + c(1, 5), when=cond_state1)
+    j.set(0, when=cond_rst_s2)
+
+    # player movement
+    player_x.set(player_x - c(1, 4), when=move_left)
+    player_x.set(player_x + c(1, 4), when=move_right)
+
+    # object Y updates
+    ob1_y.set(0, when=cond_rst_s1)
+    ob1_y.set(0, when=cond_j20)
+    ob1_y.set(ob1_y + inc1, when=cond_state1)
+    ob1_y.set(0, when=cond_rst_s2)
+
+    ob2_y.set(0, when=cond_rst_s1)
+    ob2_y.set(0, when=cond_j20)
+    ob2_y.set(ob2_y + inc2, when=cond_state1)
+    ob2_y.set(0, when=cond_rst_s2)
+
+    ob3_y.set(0, when=cond_rst_s1)
+    ob3_y.set(0, when=cond_j20)
+    ob3_y.set(ob3_y + inc3, when=cond_state1)
+    ob3_y.set(0, when=cond_rst_s2)
+
+    # VGA counters
+    vga_h_count.set(vga_h_next)
+    vga_v_count.set(vga_v_next)
+
+    # ================================================================
+    # Outputs
+    # ================================================================
+    m.output("VGA_HS_O", vga_hs)
+    m.output("VGA_VS_O", vga_vs)
+    m.output("VGA_R", vga_r)
+    m.output("VGA_G", vga_g)
+    m.output("VGA_B", vga_b)
+
+    # Debug / visualization taps
+    m.output("dbg_state", fsm_state)
+    m.output("dbg_j", j)
+    m.output("dbg_player_x", player_x)
+    m.output("dbg_ob1_x", ob1_x)
+    m.output("dbg_ob1_y", ob1_y)
+    m.output("dbg_ob2_x", ob2_x)
+    m.output("dbg_ob2_y", ob2_y)
+    m.output("dbg_ob3_x", ob3_x)
+    m.output("dbg_ob3_y", ob3_y)
+
+
+def dodgeball_top(
+    m: CycleAwareCircuit,
+    domain: CycleAwareDomain,
+    MAIN_CLK_BIT: int = 20,
+) -> None:
+    _dodgeball_impl(m, domain, MAIN_CLK_BIT=MAIN_CLK_BIT)
+
+
+def build():
+    return compile_cycle_aware(
+        dodgeball_top,
+        name="dodgeball_game",
+        MAIN_CLK_BIT=20,
+    )
+
+
+if __name__ == "__main__":
+    circuit = build()
+    print(circuit.emit_mlir())

--- a/examples/dodgeball_game/reference/lab_final_VGA.v
+++ b/examples/dodgeball_game/reference/lab_final_VGA.v
@@ -1,0 +1,56 @@
+`timescale 1ns / 1ps
+
+module vga(
+    input wire i_clk,       // base clock
+    input wire i_pix_stb,   // pixel clock strobe
+    output wire o_hs,       // horizontal sync
+    output wire o_vs,       // vertical sync
+    output wire o_blanking, // high during blanking interval
+    output wire o_animate,  // high for one tick at end of active drawing
+    output wire [9:0] o_x,  // current pixel x position: 10-bit value: 0-1023
+    output wire [8:0] o_y   // current pixel y position:  9-bit value: 0-511
+    );
+
+    localparam HS_STA = 16;              // horizontal sync start
+    localparam HS_END = 16 + 96;         // horizontal sync end
+    localparam HA_STA = 16 + 96 + 48;    // horizontal active pixel start
+    localparam VS_STA = 480 + 11;        // vertical sync start
+    localparam VS_END = 480 + 11 + 2;    // vertical sync end
+    localparam VA_END = 480;             // vertical active pixel end
+    localparam LINE   = 800;             // complete line (pixels)
+    localparam SCREEN = 524;             // complete screen (lines)
+
+    reg [9:0] h_count = 0;  // line position:   10-bit value: 0-1023
+    reg [9:0] v_count = 0;  // screen position: 10-bit value: 0-1023
+
+    // generate horizontal and vertical sync signals (both active low for 640x480)
+    assign o_hs = ~((h_count >= HS_STA) & (h_count < HS_END));
+    assign o_vs = ~((v_count >= VS_STA) & (v_count < VS_END));
+
+    // keep x and y bound within the active pixels
+    assign o_x = (h_count < HA_STA) ? 0 : (h_count - HA_STA);
+    assign o_y = (v_count >= VA_END) ? (VA_END - 1) : (v_count);
+
+    // blanking: high within the blanking period
+    assign o_blanking = ((h_count < HA_STA) | (v_count > VA_END - 1));
+
+    // animate: high for one tick at the end of the final active pixel line
+    assign o_animate = ((v_count == VA_END - 1) & (h_count == LINE));
+
+    always @ (posedge i_clk)
+    begin
+        if (i_pix_stb)  // once per pixel
+        begin
+            if (h_count == LINE)  // end of line
+            begin
+                h_count <= 0;
+                v_count <= v_count + 1;
+            end
+            else 
+                h_count <= h_count + 1;
+
+            if (v_count == SCREEN)  // end of screen
+                v_count <= 0;
+        end
+    end
+endmodule

--- a/examples/dodgeball_game/reference/lab_final_top.v
+++ b/examples/dodgeball_game/reference/lab_final_top.v
@@ -1,0 +1,139 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date: 2018/06/09 20:25:15
+// Design Name: 
+// Module Name: lab_final_top
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module top(
+    input wire CLK_in,             // board clock: 100 MHz
+    input wire RST_BTN,         // reset button
+    input wire START,           //game start
+    output wire VGA_HS_O,       // horizontal sync output
+    output wire VGA_VS_O,       // vertical sync output
+    output wire [3:0] VGA_R,    // 4-bit VGA red output
+    output wire [3:0] VGA_G,    // 4-bit VGA green output
+    output wire [3:0] VGA_B,     // 4-bit VGA blue output
+    input wire left,
+    input wire right
+    );
+
+//    wire rst = ~RST_BTN;  // reset is active low on Arty
+
+    // generate a 25 MHz pixel strobe
+    reg [15:0] cnt = 0;
+    reg pix_stb = 0;
+    reg [24:0]MAIN_CLK = 0;
+    always@(posedge CLK_in)
+            MAIN_CLK <= MAIN_CLK + 1;
+    always @(posedge CLK_in)
+        {pix_stb, cnt} <= cnt + 16'h4000;  // divide clock by 4: (2^16)/4 = 0x4000
+
+    wire [9:0] x;  // current pixel x position: 10-bit value: 0-1023
+    wire [8:0] y;  // current pixel y position:  9-bit value: 0-511
+
+    vga display (
+        .i_clk(CLK_in),
+        .i_pix_stb(pix_stb),
+        .o_hs(VGA_HS_O), 
+        .o_vs(VGA_VS_O), 
+        .o_x(x), 
+        .o_y(y)
+    );
+
+    wire sq_player;
+    wire sq_object1;
+    wire sq_object2;
+    wire sq_object3;
+    wire over_wire;
+    wire down;
+    wire up;
+        
+    reg [3:0]i=8;
+    reg [4:0]j=0;
+    
+    reg [3:0]MAIN_OB_1_x=1;
+    reg [3:0]MAIN_OB_2_x=4;
+    reg [3:0]MAIN_OB_3_x=7;
+    reg [3:0]MAIN_OB_1_y=0;
+    reg [3:0]MAIN_OB_2_y=0;
+    reg [3:0]MAIN_OB_3_y=0;
+    reg [2:0]FSM_state;
+    //0  initial
+    //1 gaming
+    //2 over
+    always@(posedge MAIN_CLK[22])begin
+        case(FSM_state)
+        0:
+        begin
+            if (START == 1)begin
+                FSM_state <= 1;
+            end
+        end
+        1:
+        begin
+            if (RST_BTN == 1)begin
+                FSM_state <= 0;
+                j <= 0;    
+                MAIN_OB_1_y <= 0;
+                MAIN_OB_2_y <= 0;
+                MAIN_OB_3_y <= 0;
+            end
+            if ((MAIN_OB_1_x == i && MAIN_OB_1_y == 10) || (MAIN_OB_2_x == i && MAIN_OB_2_y == 10) || (MAIN_OB_3_x == i && MAIN_OB_3_y == 10))
+                FSM_state <= 2;
+            if (j == 20)begin
+                j <= 0;
+                MAIN_OB_1_y <= 0;
+                MAIN_OB_2_y <= 0;
+                MAIN_OB_3_y <= 0;
+            end 
+            begin
+                j <= j+1;                      
+                MAIN_OB_1_y <= MAIN_OB_1_y + ((j>0)&&(j<13));
+                MAIN_OB_2_y <= MAIN_OB_2_y + ((j>3)&&(j<16));
+                MAIN_OB_3_y <= MAIN_OB_3_y + ((j>7)&&(j<20));
+            end
+         end
+         2:
+         begin
+            if (RST_BTN == 1)begin
+                FSM_state <= 0;
+                j <= 0;    
+                MAIN_OB_1_y <= 0;
+                MAIN_OB_2_y <= 0;
+                MAIN_OB_3_y <= 0;
+             end
+         end
+         endcase
+     end
+
+    wire circle;
+
+    assign sq_player=((x > 40*i) & (y >  400) & (x < 40*(i+1)) & (y < 440)) ? 1 : 0;
+    assign sq_object1=((x > 40*MAIN_OB_1_x) & (y >  40*MAIN_OB_1_y) & (x < 40*(MAIN_OB_1_x+1)) & (y < 40*(MAIN_OB_1_y+1))) ? 1 : 0;
+    assign sq_object2=((x > 40*MAIN_OB_2_x) & (y >  40*MAIN_OB_2_y) & (x < 40*(MAIN_OB_2_x+1)) & (y < 40*(MAIN_OB_2_y+1))) ? 1 : 0;
+    assign sq_object3=((x > 40*MAIN_OB_3_x) & (y >  40*MAIN_OB_3_y) & (x < 40*(MAIN_OB_3_x+1)) & (y < 40*(MAIN_OB_3_y+1))) ? 1 : 0;
+    assign over_wire=((x > 0) & (y >  0) & (x < 640) & (y < 480)) ? 1 : 0;
+    assign down=((x > 0) & (y >  440) & (x < 640) & (y < 480)) ? 1 : 0;
+    assign down=((x > 0) & (y >  0) & (x < 640) & (y < 40)) ? 1 : 0;
+    
+    assign VGA_R[3] = (sq_player & ~(FSM_state == 2));         // square b is red
+    assign VGA_B[3] = ((sq_object1|sq_object2|sq_object3|down|up) & ~(FSM_state == 2)); 
+    assign VGA_G[3] = (circle|(over_wire & (FSM_state == 2)));
+    
+endmodule

--- a/examples/dodgeball_game/stimuli/__init__.py
+++ b/examples/dodgeball_game/stimuli/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for dodgeball_game stimuli.

--- a/examples/dodgeball_game/stimuli/basic.py
+++ b/examples/dodgeball_game/stimuli/basic.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Basic stimulus for the dodgeball demo."""
+from __future__ import annotations
+
+
+def init(rtl) -> None:
+    rtl.rst_btn = 0
+    rtl.start = 0
+    rtl.left = 0
+    rtl.right = 0
+
+
+def total_ticks() -> int:
+    return 24
+
+
+def sleep_s() -> float:
+    return 0.08
+
+
+def step(tick: int, rtl) -> None:
+    # Start the game at tick 0
+    rtl.start = 1 if tick == 0 else 0
+
+    # Move left for a few ticks, then right
+    rtl.left = 1 if 4 <= tick < 7 else 0
+    rtl.right = 1 if 9 <= tick < 12 else 0
+
+    # Demonstrate reset and restart
+    rtl.rst_btn = 1 if tick == 16 else 0
+    if tick == 18:
+        rtl.start = 1

--- a/examples/traffic_lights_ce_pyc/PLAN.md
+++ b/examples/traffic_lights_ce_pyc/PLAN.md
@@ -1,0 +1,53 @@
+# PLAN: traffic_lights_ce_pyc
+
+## Core observations from Traffic-lights-ce
+
+- Two-direction intersection with East/West (main) and North/South (secondary).
+- Default timing: EW green 45s, EW yellow 5s, NS green 30s, NS yellow 5s.
+- Red durations are derived from the opposite direction's green+yellow (EW red = 30+5, NS red = 45+5).
+- Yellow blinks at 1 Hz during yellow phases.
+- Emergency mode forces all-red and displays "88" on both countdowns.
+- Original design uses separate countdown modules per direction and an edge-trigger to make single-cycle change pulses.
+
+## Implementation plan for pyCircuit
+
+- Build a new example under `examples/traffic_lights_ce_pyc/` with a cycle-aware design.
+- Top-level outputs are 8-bit BCD countdowns (`ew_bcd`, `ns_bcd`) plus discrete red/yellow/green lights.
+- Reuse `examples/digital_clock/bcd.py` for BCD conversion (`bin_to_bcd_60`).
+- Use a combined 4-phase FSM: EW_GREEN -> EW_YELLOW -> NS_GREEN -> NS_YELLOW -> EW_GREEN
+- Maintain two countdown registers (EW/NS). Decrement on each 1 Hz tick.
+  - Reload only the direction whose light changes.
+  - Red durations are derived from opposite green+yellow.
+- Emergency behavior:
+  - Outputs forced to all-red and BCD=0x88.
+  - Internal counters and phase freeze while `emergency=1` or `go=0`.
+- Provide a C API wrapper and a terminal emulator similar to `digital_clock`.
+
+## Deliverables
+
+- `traffic_lights_ce.py` (pyCircuit design)
+- `traffic_lights_capi.cpp` (C API wrapper)
+- `emulate_traffic_lights.py` (terminal visualization)
+- `README.md` (build and run instructions)
+- `PLAN.md` (this document)
+- `__init__.py` (package marker)
+
+## Interfaces (planned)
+
+- Inputs: `clk`, `rst`, `go`, `emergency`
+- Outputs:
+  - `ew_bcd`, `ns_bcd` (8-bit BCD, `{tens, ones}`)
+  - `ew_red/ew_yellow/ew_green`, `ns_red/ns_yellow/ns_green`
+
+## JIT parameters (planned)
+
+- `CLK_FREQ` (Hz)
+- `EW_GREEN_S`, `EW_YELLOW_S`
+- `NS_GREEN_S`, `NS_YELLOW_S`
+- Derived: `EW_RED_S = NS_GREEN_S + NS_YELLOW_S`, `NS_RED_S = EW_GREEN_S + EW_YELLOW_S`
+
+## Test/usage (planned)
+
+- Generate MLIR via `pycircuit.cli emit` with optional `--param CLK_FREQ=1000` for faster emulation.
+- Compile to Verilog/C++ using `pyc-compile --emit=verilog/cpp`.
+- Build shared lib and run `emulate_traffic_lights.py`.

--- a/examples/traffic_lights_ce_pyc/README.md
+++ b/examples/traffic_lights_ce_pyc/README.md
@@ -44,14 +44,14 @@ Derived durations:
 
 ## Build and Run
 
-The emulator assumes `CLK_FREQ=1000` for fast visualization. The following sequence is
+The emulator assumes `CLK_FREQ=1000` for fast visualization. Set it via
+`PYC_TL_CLK_FREQ=1000` when emitting the design. The following sequence is
 verified end-to-end (including all stimuli):
 
 ```bash
-PYTHONPATH=python python3 -m pycircuit.cli emit \
+PYC_TL_CLK_FREQ=1000 PYTHONPATH=python python3 -m pycircuit.cli emit \
   examples/traffic_lights_ce_pyc/traffic_lights_ce.py \
-  -o /tmp/traffic_lights_ce_pyc.pyc \
-  --param CLK_FREQ=1000
+  -o /tmp/traffic_lights_ce_pyc.pyc
 
 ./build/bin/pyc-compile /tmp/traffic_lights_ce_pyc.pyc \
   --emit=verilog --out-dir=examples/generated/traffic_lights_ce_pyc
@@ -76,11 +76,3 @@ Available modules live under `examples/traffic_lights_ce_pyc/stimuli/`.
 - `basic`: continuous run, no interruptions
 - `emergency_pulse`: assert emergency for a window
 - `pause_resume`: toggle `go` to pause/resume
-
-Examples:
-
-```bash
-python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim basic
-python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim emergency_pulse
-python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim pause_resume
-```

--- a/examples/traffic_lights_ce_pyc/README.md
+++ b/examples/traffic_lights_ce_pyc/README.md
@@ -1,0 +1,86 @@
+# Traffic Lights (pyCircuit)
+
+A cycle-aware traffic lights controller based on the [Traffic-lights-ce](https://github.com/Starrynightzyq/Traffic-lights-ce) design.
+It exposes BCD countdowns for East/West and North/South, plus discrete red/yellow/green lights.
+The terminal emulator renders a simple 7-seg view and can load multiple stimulus patterns.
+
+**Key files**
+- `traffic_lights_ce.py`: pyCircuit implementation of the FSM, countdowns, blink, and outputs.
+- `traffic_lights_capi.cpp`: C API wrapper around the generated C++ model for ctypes.
+- `emulate_traffic_lights.py`: terminal visualization; drives the DUT via the C API.
+- `stimuli/*.py`: independent stimulus modules (driver logic separated from the DUT).
+- `PLAN.md`: design notes and implementation plan.
+
+## Ports
+
+| Port | Dir | Width | Description |
+|------|-----|-------|-------------|
+| `clk` | in | 1 | System clock |
+| `rst` | in | 1 | Synchronous reset |
+| `go` | in | 1 | Run/pause (1=run, 0=freeze) |
+| `emergency` | in | 1 | Emergency override (1=all red, BCD=88) |
+| `ew_bcd` | out | 8 | East/West countdown BCD `{tens,ones}` |
+| `ns_bcd` | out | 8 | North/South countdown BCD `{tens,ones}` |
+| `ew_red` | out | 1 | East/West red |
+| `ew_yellow` | out | 1 | East/West yellow (blink) |
+| `ew_green` | out | 1 | East/West green |
+| `ns_red` | out | 1 | North/South red |
+| `ns_yellow` | out | 1 | North/South yellow (blink) |
+| `ns_green` | out | 1 | North/South green |
+
+## JIT parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `CLK_FREQ` | 50_000_000 | System clock frequency (Hz) |
+| `EW_GREEN_S` | 45 | East/West green time (seconds) |
+| `EW_YELLOW_S` | 5 | East/West yellow time (seconds) |
+| `NS_GREEN_S` | 30 | North/South green time (seconds) |
+| `NS_YELLOW_S` | 5 | North/South yellow time (seconds) |
+
+Derived durations:
+- `EW_RED_S = NS_GREEN_S + NS_YELLOW_S`
+- `NS_RED_S = EW_GREEN_S + EW_YELLOW_S`
+
+## Build and Run
+
+The emulator assumes `CLK_FREQ=1000` for fast visualization. The following sequence is
+verified end-to-end (including all stimuli):
+
+```bash
+PYTHONPATH=python python3 -m pycircuit.cli emit \
+  examples/traffic_lights_ce_pyc/traffic_lights_ce.py \
+  -o /tmp/traffic_lights_ce_pyc.pyc \
+  --param CLK_FREQ=1000
+
+./build/bin/pyc-compile /tmp/traffic_lights_ce_pyc.pyc \
+  --emit=verilog --out-dir=examples/generated/traffic_lights_ce_pyc
+
+./build/bin/pyc-compile /tmp/traffic_lights_ce_pyc.pyc \
+  --emit=cpp --out-dir=examples/generated/traffic_lights_ce_pyc
+
+c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
+  -o examples/traffic_lights_ce_pyc/libtraffic_lights_sim.dylib \
+  examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
+
+python3 examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim basic
+python3 examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim emergency_pulse
+python3 examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim pause_resume
+```
+
+## Stimuli
+
+Stimulus is loaded as an independent module, separate from the DUT.
+Available modules live under `examples/traffic_lights_ce_pyc/stimuli/`.
+
+- `basic`: continuous run, no interruptions
+- `emergency_pulse`: assert emergency for a window
+- `pause_resume`: toggle `go` to pause/resume
+
+Examples:
+
+```bash
+python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim basic
+python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim emergency_pulse
+python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim pause_resume
+```

--- a/examples/traffic_lights_ce_pyc/__init__.py
+++ b/examples/traffic_lights_ce_pyc/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for traffic_lights_ce_pyc example.

--- a/examples/traffic_lights_ce_pyc/emulate_traffic_lights.py
+++ b/examples/traffic_lights_ce_pyc/emulate_traffic_lights.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+emulate_traffic_lights.py — True RTL simulation of the traffic lights
+with a terminal visualization.
+
+Build the shared library first:
+  cd <pyCircuit root>
+  c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
+      -o examples/traffic_lights_ce_pyc/libtraffic_lights_sim.dylib \
+      examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
+
+Then run:
+  python examples/traffic_lights_ce_pyc/emulate_traffic_lights.py
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import importlib
+import sys
+import time
+from pathlib import Path
+
+# =============================================================================
+# ANSI helpers
+# =============================================================================
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+GREEN = "\033[32m"
+WHITE = "\033[37m"
+CYAN = "\033[36m"
+
+
+def clear_screen() -> None:
+    print("\033[2J\033[H", end="")
+
+
+# =============================================================================
+# 7-segment ASCII art
+# =============================================================================
+
+_SEG = {
+    0: (" _ ", "| |", "|_|"),
+    1: ("   ", "  |", "  |"),
+    2: (" _ ", " _|", "|_ "),
+    3: (" _ ", " _|", " _|"),
+    4: ("   ", "|_|", "  |"),
+    5: (" _ ", "|_ ", " _|"),
+    6: (" _ ", "|_ ", "|_|"),
+    7: (" _ ", "  |", "  |"),
+    8: (" _ ", "|_|", "|_|"),
+    9: (" _ ", "|_|", " _|"),
+}
+
+
+def _digit_rows(d: int, color: str = WHITE) -> list[str]:
+    rows = _SEG.get(d, _SEG[0])
+    return [f"{color}{r}{RESET}" for r in rows]
+
+
+def _light(on: int, color: str, label: str) -> str:
+    return f"{color}{label}{RESET}" if on else f"{DIM}{label}{RESET}"
+
+
+# =============================================================================
+# RTL simulation wrapper (ctypes -> compiled C++ netlist)
+# =============================================================================
+
+# Must match the CLK_FREQ used when generating the RTL for this demo.
+RTL_CLK_FREQ = 1000
+
+
+class TrafficLightsRTL:
+    def __init__(self, lib_path: str | None = None):
+        if lib_path is None:
+            lib_path = str(Path(__file__).resolve().parent / "libtraffic_lights_sim.dylib")
+        self._lib = ctypes.CDLL(lib_path)
+
+        self._lib.tl_create.restype = ctypes.c_void_p
+        self._lib.tl_destroy.argtypes = [ctypes.c_void_p]
+        self._lib.tl_reset.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        self._lib.tl_set_inputs.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
+        self._lib.tl_tick.argtypes = [ctypes.c_void_p]
+        self._lib.tl_run_cycles.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+
+        for name in (
+            "tl_get_ew_bcd", "tl_get_ns_bcd",
+            "tl_get_ew_red", "tl_get_ew_yellow", "tl_get_ew_green",
+            "tl_get_ns_red", "tl_get_ns_yellow", "tl_get_ns_green",
+        ):
+            getattr(self._lib, name).argtypes = [ctypes.c_void_p]
+            getattr(self._lib, name).restype = ctypes.c_uint32
+
+        self._lib.tl_get_cycle.argtypes = [ctypes.c_void_p]
+        self._lib.tl_get_cycle.restype = ctypes.c_uint64
+
+        self._ctx = self._lib.tl_create()
+        self.go = 0
+        self.emergency = 0
+
+    def __del__(self):
+        if hasattr(self, "_ctx") and self._ctx:
+            self._lib.tl_destroy(self._ctx)
+
+    def reset(self, cycles: int = 2):
+        self._lib.tl_reset(self._ctx, cycles)
+
+    def _apply_inputs(self):
+        self._lib.tl_set_inputs(self._ctx, self.go, self.emergency)
+
+    def tick(self):
+        self._apply_inputs()
+        self._lib.tl_tick(self._ctx)
+
+    def run_cycles(self, n: int):
+        self._apply_inputs()
+        self._lib.tl_run_cycles(self._ctx, n)
+
+    @property
+    def ew_bcd(self) -> tuple[int, int]:
+        v = self._lib.tl_get_ew_bcd(self._ctx)
+        return ((v >> 4) & 0xF, v & 0xF)
+
+    @property
+    def ns_bcd(self) -> tuple[int, int]:
+        v = self._lib.tl_get_ns_bcd(self._ctx)
+        return ((v >> 4) & 0xF, v & 0xF)
+
+    @property
+    def ew_lights(self) -> tuple[int, int, int]:
+        return (
+            int(self._lib.tl_get_ew_red(self._ctx)),
+            int(self._lib.tl_get_ew_yellow(self._ctx)),
+            int(self._lib.tl_get_ew_green(self._ctx)),
+        )
+
+    @property
+    def ns_lights(self) -> tuple[int, int, int]:
+        return (
+            int(self._lib.tl_get_ns_red(self._ctx)),
+            int(self._lib.tl_get_ns_yellow(self._ctx)),
+            int(self._lib.tl_get_ns_green(self._ctx)),
+        )
+
+    @property
+    def cycle(self) -> int:
+        return int(self._lib.tl_get_cycle(self._ctx))
+
+
+# =============================================================================
+# Rendering
+# =============================================================================
+
+
+def render_direction(label: str, tens: int, ones: int, lights: tuple[int, int, int]) -> list[str]:
+    r, y, g = lights
+    lights_str = " ".join([
+        _light(r, RED, "R"),
+        _light(y, YELLOW, "Y"),
+        _light(g, GREEN, "G"),
+    ])
+    header = f"{BOLD}{label}{RESET}  {lights_str}"
+
+    d0 = _digit_rows(tens, WHITE)
+    d1 = _digit_rows(ones, WHITE)
+
+    lines = [header]
+    for i in range(3):
+        lines.append(f"  {d0[i]} {d1[i]}")
+    return lines
+
+
+def _load_stimulus(name: str):
+    if "." in name:
+        return importlib.import_module(name)
+    try:
+        return importlib.import_module(f"examples.traffic_lights_ce_pyc.stimuli.{name}")
+    except ModuleNotFoundError:
+        root = Path(__file__).resolve().parents[2]
+        sys.path.insert(0, str(root))
+        return importlib.import_module(f"examples.traffic_lights_ce_pyc.stimuli.{name}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Traffic lights terminal emulator")
+    ap.add_argument(
+        "--stim",
+        default="emergency_pulse",
+        help="Stimulus module name (e.g. basic, emergency_pulse, pause_resume)",
+    )
+    args = ap.parse_args()
+
+    stim = _load_stimulus(args.stim)
+
+    rtl = TrafficLightsRTL()
+    rtl.reset()
+    if hasattr(stim, "init"):
+        stim.init(rtl)
+    else:
+        rtl.go = 1
+        rtl.emergency = 0
+
+    total_seconds = int(getattr(stim, "total_seconds", lambda: 120)())
+    sleep_s = float(getattr(stim, "sleep_s", lambda: 0.08)())
+
+    for sec in range(total_seconds):
+        if hasattr(stim, "step"):
+            stim.step(sec, rtl)
+
+        clear_screen()
+        ew_t, ew_o = rtl.ew_bcd
+        ns_t, ns_o = rtl.ns_bcd
+
+        ew_lines = render_direction("EW", ew_t, ew_o, rtl.ew_lights)
+        ns_lines = render_direction("NS", ns_t, ns_o, rtl.ns_lights)
+
+        print(f"{CYAN}traffic_lights_ce_pyc{RESET}  cycle={rtl.cycle}  sec={sec}")
+        print(f"go={rtl.go}  emergency={rtl.emergency}  CLK_FREQ={RTL_CLK_FREQ}")
+        print("")
+        for line in ew_lines:
+            print(line)
+        print("")
+        for line in ns_lines:
+            print(line)
+
+        rtl.run_cycles(RTL_CLK_FREQ)
+        time.sleep(sleep_s)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/traffic_lights_ce_pyc/emulate_traffic_lights.py
+++ b/examples/traffic_lights_ce_pyc/emulate_traffic_lights.py
@@ -193,6 +193,11 @@ def main():
         default="emergency_pulse",
         help="Stimulus module name (e.g. basic, emergency_pulse, pause_resume)",
     )
+    ap.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print extra debug info (BCD values as integers)",
+    )
     args = ap.parse_args()
 
     stim = _load_stimulus(args.stim)
@@ -219,8 +224,12 @@ def main():
         ew_lines = render_direction("EW", ew_t, ew_o, rtl.ew_lights)
         ns_lines = render_direction("NS", ns_t, ns_o, rtl.ns_lights)
 
+        ew_val = ew_t * 10 + ew_o
+        ns_val = ns_t * 10 + ns_o
         print(f"{CYAN}traffic_lights_ce_pyc{RESET}  cycle={rtl.cycle}  sec={sec}")
         print(f"go={rtl.go}  emergency={rtl.emergency}  CLK_FREQ={RTL_CLK_FREQ}")
+        if args.debug:
+            print(f"ew_bcd={ew_t}{ew_o} ({ew_val})  ns_bcd={ns_t}{ns_o} ({ns_val})")
         print("")
         for line in ew_lines:
             print(line)

--- a/examples/traffic_lights_ce_pyc/stimuli/__init__.py
+++ b/examples/traffic_lights_ce_pyc/stimuli/__init__.py
@@ -1,0 +1,1 @@
+"""Stimulus modules for traffic_lights_ce_pyc emulator."""

--- a/examples/traffic_lights_ce_pyc/stimuli/basic.py
+++ b/examples/traffic_lights_ce_pyc/stimuli/basic.py
@@ -1,0 +1,20 @@
+"""Basic stimulus: run continuously with no interruptions."""
+
+
+def total_seconds() -> int:
+    return 120
+
+
+def sleep_s() -> float:
+    return 0.08
+
+
+def init(rtl) -> None:
+    rtl.go = 1
+    rtl.emergency = 0
+
+
+def step(sec: int, rtl) -> None:
+    _ = sec
+    _ = rtl
+    # No changes during run.

--- a/examples/traffic_lights_ce_pyc/stimuli/emergency_pulse.py
+++ b/examples/traffic_lights_ce_pyc/stimuli/emergency_pulse.py
@@ -1,0 +1,21 @@
+"""Emergency pulse stimulus: inject emergency for a short window."""
+
+
+def total_seconds() -> int:
+    return 140
+
+
+def sleep_s() -> float:
+    return 0.08
+
+
+def init(rtl) -> None:
+    rtl.go = 1
+    rtl.emergency = 0
+
+
+def step(sec: int, rtl) -> None:
+    if sec == 60:
+        rtl.emergency = 1
+    if sec == 72:
+        rtl.emergency = 0

--- a/examples/traffic_lights_ce_pyc/stimuli/pause_resume.py
+++ b/examples/traffic_lights_ce_pyc/stimuli/pause_resume.py
@@ -1,0 +1,21 @@
+"""Pause/resume stimulus: toggles go while running."""
+
+
+def total_seconds() -> int:
+    return 140
+
+
+def sleep_s() -> float:
+    return 0.08
+
+
+def init(rtl) -> None:
+    rtl.go = 1
+    rtl.emergency = 0
+
+
+def step(sec: int, rtl) -> None:
+    if sec == 50:
+        rtl.go = 0
+    if sec == 65:
+        rtl.go = 1

--- a/examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
+++ b/examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
@@ -1,0 +1,73 @@
+/**
+ * traffic_lights_capi.cpp — C API wrapper around the generated RTL model.
+ *
+ * Build:
+ *   cd <pyCircuit root>
+ *   c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
+ *       -o examples/traffic_lights_ce_pyc/libtraffic_lights_sim.dylib \
+ *       examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
+ */
+
+#include <cstdint>
+#include <pyc/cpp/pyc_sim.hpp>
+#include <pyc/cpp/pyc_tb.hpp>
+
+#include "../generated/traffic_lights_ce_pyc/traffic_lights_ce_pyc.hpp"
+
+using pyc::cpp::Wire;
+
+struct SimContext {
+    pyc::gen::traffic_lights_ce_pyc dut{};
+    pyc::cpp::Testbench<pyc::gen::traffic_lights_ce_pyc> tb;
+    uint64_t cycle = 0;
+
+    SimContext() : tb(dut) {
+        tb.addClock(dut.clk, /*halfPeriodSteps=*/1);
+    }
+};
+
+extern "C" {
+
+SimContext* tl_create() {
+    return new SimContext();
+}
+
+void tl_destroy(SimContext* ctx) {
+    delete ctx;
+}
+
+void tl_reset(SimContext* ctx, uint64_t cycles) {
+    ctx->tb.reset(ctx->dut.rst, /*cyclesAsserted=*/cycles, /*cyclesDeasserted=*/1);
+    ctx->dut.eval();
+    ctx->cycle = 0;
+}
+
+void tl_set_inputs(SimContext* ctx, int go, int emergency) {
+    ctx->dut.go = Wire<1>(go ? 1u : 0u);
+    ctx->dut.emergency = Wire<1>(emergency ? 1u : 0u);
+}
+
+void tl_tick(SimContext* ctx) {
+    ctx->tb.runCycles(1);
+    ctx->cycle++;
+}
+
+void tl_run_cycles(SimContext* ctx, uint64_t n) {
+    ctx->tb.runCycles(n);
+    ctx->cycle += n;
+}
+
+uint32_t tl_get_ew_bcd(SimContext* ctx) { return ctx->dut.ew_bcd.value(); }
+uint32_t tl_get_ns_bcd(SimContext* ctx) { return ctx->dut.ns_bcd.value(); }
+
+uint32_t tl_get_ew_red(SimContext* ctx) { return ctx->dut.ew_red.value(); }
+uint32_t tl_get_ew_yellow(SimContext* ctx) { return ctx->dut.ew_yellow.value(); }
+uint32_t tl_get_ew_green(SimContext* ctx) { return ctx->dut.ew_green.value(); }
+
+uint32_t tl_get_ns_red(SimContext* ctx) { return ctx->dut.ns_red.value(); }
+uint32_t tl_get_ns_yellow(SimContext* ctx) { return ctx->dut.ns_yellow.value(); }
+uint32_t tl_get_ns_green(SimContext* ctx) { return ctx->dut.ns_green.value(); }
+
+uint64_t tl_get_cycle(SimContext* ctx) { return ctx->cycle; }
+
+} // extern "C"

--- a/examples/traffic_lights_ce_pyc/traffic_lights_ce.py
+++ b/examples/traffic_lights_ce_pyc/traffic_lights_ce.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""Traffic Lights Controller — pyCircuit cycle-aware design.
+
+Reimplements the Traffic-lights-ce project in the pyCircuit unified signal model.
+Outputs are BCD countdowns per direction plus discrete red/yellow/green lights.
+
+JIT parameters:
+  CLK_FREQ     — system clock frequency in Hz (default 50 MHz)
+  EW_GREEN_S   — east/west green time in seconds
+  EW_YELLOW_S  — east/west yellow time in seconds
+  NS_GREEN_S   — north/south green time in seconds
+  NS_YELLOW_S  — north/south yellow time in seconds
+
+Derived:
+  EW_RED_S = NS_GREEN_S + NS_YELLOW_S
+  NS_RED_S = EW_GREEN_S + EW_YELLOW_S
+"""
+from __future__ import annotations
+
+from pycircuit import (
+    CycleAwareCircuit,
+    CycleAwareDomain,
+    compile_cycle_aware,
+    mux,
+)
+
+try:
+    from examples.digital_clock.bcd import bin_to_bcd_60
+except ImportError:
+    import sys
+    from pathlib import Path
+    _ROOT = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(_ROOT))
+    from examples.digital_clock.bcd import bin_to_bcd_60
+
+
+# Phase encoding
+PH_EW_GREEN  = 0
+PH_EW_YELLOW = 1
+PH_NS_GREEN  = 2
+PH_NS_YELLOW = 3
+
+
+def _traffic_lights_impl(
+    m: CycleAwareCircuit,
+    domain: CycleAwareDomain,
+    CLK_FREQ: int,
+    EW_GREEN_S: int,
+    EW_YELLOW_S: int,
+    NS_GREEN_S: int,
+    NS_YELLOW_S: int,
+) -> None:
+    if min(EW_GREEN_S, EW_YELLOW_S, NS_GREEN_S, NS_YELLOW_S) <= 0:
+        raise ValueError("all durations must be > 0")
+
+    EW_RED_S = NS_GREEN_S + NS_YELLOW_S
+    NS_RED_S = EW_GREEN_S + EW_YELLOW_S
+
+    max_dur = max(EW_GREEN_S, EW_YELLOW_S, NS_GREEN_S, NS_YELLOW_S, EW_RED_S, NS_RED_S)
+    if max_dur > 59:
+        raise ValueError("all durations must be <= 59 to fit bin_to_bcd_60")
+
+    c = lambda v, w: domain.const(v, width=w)
+
+    # ================================================================
+    # Inputs
+    # ================================================================
+    go = domain.input("go", width=1)
+    emergency = domain.input("emergency", width=1)
+
+    # ================================================================
+    # Flops (Q outputs at cycle 0)
+    # ================================================================
+    PRESCALER_W = max((CLK_FREQ - 1).bit_length(), 1)
+    CNT_W = max(max_dur.bit_length(), 1)
+
+    prescaler_r = domain.signal("prescaler", width=PRESCALER_W, reset=0)
+    phase_r = domain.signal("phase", width=2, reset=PH_EW_GREEN)
+    ew_cnt_r = domain.signal("ew_cnt", width=CNT_W, reset=EW_GREEN_S)
+    ns_cnt_r = domain.signal("ns_cnt", width=CNT_W, reset=NS_RED_S)
+    blink_r = domain.signal("blink", width=1, reset=0)
+
+    # ================================================================
+    # Combinational logic (cycle 0)
+    # ================================================================
+    en = go & (~emergency)
+
+    # 1 Hz tick via prescaler (gated by en)
+    tick_raw = prescaler_r.eq(c(CLK_FREQ - 1, PRESCALER_W))
+    tick_1hz = tick_raw & en
+    prescaler_next = mux(en, mux(tick_raw, c(0, PRESCALER_W), prescaler_r + 1), prescaler_r)
+
+    # Phase flags
+    is_ew_green = phase_r.eq(c(PH_EW_GREEN, 2))
+    is_ew_yellow = phase_r.eq(c(PH_EW_YELLOW, 2))
+    is_ns_green = phase_r.eq(c(PH_NS_GREEN, 2))
+    is_ns_yellow = phase_r.eq(c(PH_NS_YELLOW, 2))
+    yellow_active = is_ew_yellow | is_ns_yellow
+
+    # Countdown end flags (1 -> reload at next tick)
+    ew_end = ew_cnt_r.eq(c(1, CNT_W))
+    ns_end = ns_cnt_r.eq(c(1, CNT_W))
+
+    ew_cnt_dec = ew_cnt_r - 1
+    ns_cnt_dec = ns_cnt_r - 1
+
+    # Phase transitions
+    cond_ew_to_yellow = tick_1hz & is_ew_green & ew_end
+    cond_ew_to_ns_green = tick_1hz & is_ew_yellow & ew_end
+    cond_ns_to_yellow = tick_1hz & is_ns_green & ns_end
+    cond_ns_to_ew_green = tick_1hz & is_ns_yellow & ns_end
+
+    phase_next = phase_r
+    phase_next = mux(cond_ew_to_yellow, c(PH_EW_YELLOW, 2), phase_next)
+    phase_next = mux(cond_ew_to_ns_green, c(PH_NS_GREEN, 2), phase_next)
+    phase_next = mux(cond_ns_to_yellow, c(PH_NS_YELLOW, 2), phase_next)
+    phase_next = mux(cond_ns_to_ew_green, c(PH_EW_GREEN, 2), phase_next)
+
+    # EW countdown
+    ew_cnt_next = ew_cnt_r
+    ew_cnt_next = mux(tick_1hz, ew_cnt_dec, ew_cnt_next)
+    ew_cnt_next = mux(cond_ew_to_yellow, c(EW_YELLOW_S, CNT_W), ew_cnt_next)
+    ew_cnt_next = mux(cond_ew_to_ns_green, c(EW_RED_S, CNT_W), ew_cnt_next)
+    ew_cnt_next = mux(cond_ns_to_ew_green, c(EW_GREEN_S, CNT_W), ew_cnt_next)
+
+    # NS countdown
+    ns_cnt_next = ns_cnt_r
+    ns_cnt_next = mux(tick_1hz, ns_cnt_dec, ns_cnt_next)
+    ns_cnt_next = mux(cond_ew_to_ns_green, c(NS_GREEN_S, CNT_W), ns_cnt_next)
+    ns_cnt_next = mux(cond_ns_to_yellow, c(NS_YELLOW_S, CNT_W), ns_cnt_next)
+    ns_cnt_next = mux(cond_ns_to_ew_green, c(NS_RED_S, CNT_W), ns_cnt_next)
+
+    # BCD conversion (combinational)
+    ew_bcd_raw = bin_to_bcd_60(domain, ew_cnt_r, "ew")
+    ns_bcd_raw = bin_to_bcd_60(domain, ns_cnt_r, "ns")
+
+    # Lights (base, before emergency override)
+    ew_red_base = is_ns_green | is_ns_yellow
+    ew_green_base = is_ew_green
+    ew_yellow_base = is_ew_yellow & blink_r
+
+    ns_red_base = is_ew_green | is_ew_yellow
+    ns_green_base = is_ns_green
+    ns_yellow_base = is_ns_yellow & blink_r
+
+    # Emergency overrides
+    ew_bcd = mux(emergency, c(0x88, 8), ew_bcd_raw)
+    ns_bcd = mux(emergency, c(0x88, 8), ns_bcd_raw)
+
+    ew_red = mux(emergency, c(1, 1), ew_red_base)
+    ew_yellow = mux(emergency, c(0, 1), ew_yellow_base)
+    ew_green = mux(emergency, c(0, 1), ew_green_base)
+
+    ns_red = mux(emergency, c(1, 1), ns_red_base)
+    ns_yellow = mux(emergency, c(0, 1), ns_yellow_base)
+    ns_green = mux(emergency, c(0, 1), ns_green_base)
+
+    # ================================================================
+    # DFF boundary
+    # ================================================================
+    domain.next()
+
+    # ================================================================
+    # Flop updates
+    # ================================================================
+    prescaler_r.set(prescaler_next)
+    phase_r.set(phase_next)
+    ew_cnt_r.set(ew_cnt_next)
+    ns_cnt_r.set(ns_cnt_next)
+
+    # Blink: toggle on tick_1hz while in yellow; reset to 0 when not yellow.
+    blink_r.set(blink_r)
+    blink_r.set(0, when=~yellow_active)
+    blink_r.set(~blink_r, when=tick_1hz & yellow_active)
+
+    # ================================================================
+    # Outputs
+    # ================================================================
+    m.output("ew_bcd", ew_bcd)
+    m.output("ns_bcd", ns_bcd)
+    m.output("ew_red", ew_red)
+    m.output("ew_yellow", ew_yellow)
+    m.output("ew_green", ew_green)
+    m.output("ns_red", ns_red)
+    m.output("ns_yellow", ns_yellow)
+    m.output("ns_green", ns_green)
+
+
+# ------------------------------------------------------------------
+# Public entry point (with JIT parameters)
+# ------------------------------------------------------------------
+
+def traffic_lights_ce_pyc(
+    m: CycleAwareCircuit,
+    domain: CycleAwareDomain,
+    CLK_FREQ: int = 50_000_000,
+    EW_GREEN_S: int = 45,
+    EW_YELLOW_S: int = 5,
+    NS_GREEN_S: int = 30,
+    NS_YELLOW_S: int = 5,
+) -> None:
+    _traffic_lights_impl(
+        m, domain,
+        CLK_FREQ=CLK_FREQ,
+        EW_GREEN_S=EW_GREEN_S,
+        EW_YELLOW_S=EW_YELLOW_S,
+        NS_GREEN_S=NS_GREEN_S,
+        NS_YELLOW_S=NS_YELLOW_S,
+    )
+
+
+# ------------------------------------------------------------------
+# CLI entry point: pycircuit.cli expects `build` -> Module.
+# ------------------------------------------------------------------
+
+def build():
+    return compile_cycle_aware(
+        traffic_lights_ce_pyc,
+        name="traffic_lights_ce_pyc",
+        CLK_FREQ=50_000_000,
+        EW_GREEN_S=45,
+        EW_YELLOW_S=5,
+        NS_GREEN_S=30,
+        NS_YELLOW_S=5,
+    )
+
+
+# ------------------------------------------------------------------
+# Standalone compile
+# ------------------------------------------------------------------
+
+if __name__ == "__main__":
+    circuit = build()
+    print(circuit.emit_mlir())


### PR DESCRIPTION
## Summary

### traffic lights

Ported the existing traffic-lights Verilog project into a cycle-aware pyCircuit example.
Reused the digital_clock BCD conversion logic for countdown display.
Added a terminal emulator with multiple stimulus options for quick verification.

### dodgeball game

Add a pyCircuit rewrite of the dodgeball VGA demo (top + VGA timing) with left/right movement and faster game tick.
Add terminal emulator with downsampled VGA rendering plus auto-build of the C++ sim.
Add C API wrapper, stimuli module, README, and include the reference Verilog files.

## Key Changes

New examples/traffic_lights_ce_pyc design with BCD countdown outputs and light state logic.
C++ C-API wrapper for ctypes-based simulation.
Terminal visualization script and modular stimuli (basic, emergency pulse, pause/resume).

## How to Run (quick)

### traffic lights

```
PYC_TL_CLK_FREQ=1000 PYTHONPATH=python python3 -m pycircuit.cli emit \
  examples/traffic_lights_ce_pyc/traffic_lights_ce.py -o /tmp/traffic_lights_ce_pyc.pyc
./build/bin/pyc-compile /tmp/traffic_lights_ce_pyc.pyc --emit=cpp --out-dir=examples/generated/traffic_lights_ce_pyc
c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
  -o examples/traffic_lights_ce_pyc/libtraffic_lights_sim.dylib \
  examples/traffic_lights_ce_pyc/traffic_lights_capi.cpp
python3 examples/traffic_lights_ce_pyc/emulate_traffic_lights.py --stim basic
```

https://github.com/user-attachments/assets/b8bd67bb-b966-49b3-ab66-ab43affe3f96
### dodge ball

```
# 1) 生成 PYC
PYTHONPATH=python:. python3 -m pycircuit.cli emit \
  examples/dodgeball_game/lab_final_top.py \
  -o examples/generated/dodgeball_game/dodgeball_game.pyc

# 2) 生成 C++ 模型
./build/bin/pyc-compile examples/generated/dodgeball_game/dodgeball_game.pyc \
  --emit=cpp --out-dir=examples/generated/dodgeball_game

# 3) 编译动态库
c++ -std=c++17 -O2 -shared -fPIC -I include -I . \
  -o examples/dodgeball_game/libdodgeball_sim.dylib \
  examples/dodgeball_game/dodgeball_capi.cpp

# 4) 运行演示
python3 examples/dodgeball_game/emulate_dodgeball.py --stim basic

```

https://github.com/user-attachments/assets/08ff132b-59e9-4332-89d0-60955a5d810c

## Notes

BCD logic and terminal UI patterns were reused from examples/digital_clock.


