### PR TITLE
fix: one driver per register — chain guarded writes, refuse multi-driver nets (Decision 0130)

### DIFF
--- a/compiler/frontend/pycircuit/hw.py
+++ b/compiler/frontend/pycircuit/hw.py
@@ -833,7 +833,9 @@ class Reg(Generic[DT]):
         next_w = Wire.as_wire(value, m=m, width=self.width)
 
         if isinstance(when, int) and int(when) == 1:
-            m.assign(self.next, next_w)
+            # Unconditional write: overrides every earlier write to this register in
+            # this cycle (plain last-write-wins), so it *becomes* the running value.
+            self._pyc_drive(m, next_w)
             return
         
         cond = Wire.as_wire(when, m=m, width=1)
@@ -841,7 +843,71 @@ class Reg(Generic[DT]):
             raise TypeError("when width must be 1")
         when_w = Wire.as_wire(when, m=m)
 
-        m.assign(self.next, when_w._select_internal(value, self.q))
+        # Guarded write. The else-branch must be the value accumulated by the writes
+        # that came before it — NOT `self.q`. See _pyc_drive for why.
+        prev = self._pyc_running_value(m)
+        self._pyc_drive(m, when_w._select_internal(value, prev))
+
+    # ── one register, one driver (F13) ──────────────────────────────────────
+    #
+    # `set(v, when=c)` used to emit, per call, an independent
+    #     pyc.assign next, mux(c, v, q)
+    # so N guarded writes to one register produced N assigns, each defaulting to the
+    # register's *current* value rather than to the running next-state value. That is
+    # wrong in two separate ways:
+    #
+    #   * Semantically. The DSL contract is that later writes override earlier ones and
+    #     an unguarded register holds. Because every mux fell back to `q`, the last
+    #     assign unconditionally decided the outcome: with writes (c0,v0)…(cN,vN), the
+    #     result was `cN ? vN : q`, discarding c0…cN-1 entirely. DavinciOO's free list
+    #     (srcs/core/common/free_list.py) issues exactly this pattern once per enqueue
+    #     port, so only the last port's enqueue could ever take effect.
+    #   * Structurally. N assigns to one wire is N continuous drivers in Verilog, which
+    #     is undefined and which yosys/verilator resolve arbitrarily (report F13:
+    #     2 470 conflicting driver bits across 321 nets in davinci_top).
+    #
+    # Both follow from the same root cause, so both are fixed here rather than in the
+    # emitters: chain the muxes into a single priority expression (later guard wins,
+    # `q` as the base case) and keep exactly ONE `pyc.assign` per register, by superseding
+    # the assign already emitted rather than adding a second one (see `_pyc_drive`). With
+    # one correct driver the C++ and Verilog backends agree by construction and neither
+    # emitter needs to change.
+    #
+    # State lives on the Module (keyed by the next-wire ref) because Reg is a frozen
+    # dataclass; it is per-Module and therefore per-elaboration, which is the right
+    # lifetime.
+
+    _PYC_DRIVE_ATTR = "_pyc_reg_next_drive"
+
+    def _pyc_drive_table(self, m: "Module") -> dict:
+        table = getattr(m, Reg._PYC_DRIVE_ATTR, None)
+        if table is None:
+            table = {}
+            setattr(m, Reg._PYC_DRIVE_ATTR, table)
+        return table
+
+    def _pyc_running_value(self, m: "Module") -> "Wire":
+        """The value accumulated so far for this register's next-state, else `q`."""
+        entry = self._pyc_drive_table(m).get(self.next.ref)
+        return entry[0] if entry is not None else self.q
+
+    def _pyc_drive(self, m: "Module", value: "Wire") -> None:
+        """Assign `value` to this register's next wire, replacing any prior assign.
+
+        The replacement must be *appended*, not written back over the old line: `value`
+        is a freshly built mux whose SSA definition comes after the previous assign's
+        position, so patching the old slot in place would emit a use before its def and
+        break MLIR's dominance rule. Instead blank the superseded line — which keeps
+        every other register's recorded index valid, unlike deleting it — and emit the
+        new assign at the end, where all its operands are in scope.
+        """
+        table = self._pyc_drive_table(m)
+        entry = table.get(self.next.ref)
+        if entry is not None:
+            _, idx = entry
+            m._lines[idx] = ""
+        m.assign(self.next, value)
+        table[self.next.ref] = (value, len(m._lines) - 1)
 
 class Circuit(Module):
     """High-level wrapper over `Module` that returns `Wire`/`Reg` objects."""

--- a/compiler/mlir/include/pyc/Emit/VerilogEmitter.h
+++ b/compiler/mlir/include/pyc/Emit/VerilogEmitter.h
@@ -10,6 +10,11 @@ namespace pyc {
 struct VerilogEmitterOptions {
   bool includePrimitives = true;
   bool targetFpga = false;
+  // Emit a net that has more than one `pyc.assign` anyway, instead of failing.
+  // Two continuous drivers on one net is undefined in Verilog and the emitter
+  // has no way to pick a winner, so this produces a netlist that does not
+  // implement the design; it exists only to reproduce the historical output.
+  bool allowMultiDriven = false;
 };
 
 ::mlir::LogicalResult emitVerilog(::mlir::ModuleOp module, ::llvm::raw_ostream &os,

--- a/compiler/mlir/lib/Emit/VerilogEmitter.cpp
+++ b/compiler/mlir/lib/Emit/VerilogEmitter.cpp
@@ -10,6 +10,7 @@
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringMap.h"
@@ -806,6 +807,77 @@ static std::string opSortKey(Operation *op, NameTable &nt) {
   return "";
 }
 
+// A `pyc.assign` lowers to a continuous `assign`, which is a DRIVER, not a
+// statement: two of them on one net are two drivers fighting, and Verilog
+// leaves the result undefined. The C++ emitter lowers the same op to `dst =
+// src;`, a statement with last-write-wins semantics, so a design that assigns
+// one net twice means two different things in the two backends — and the
+// Verilog one means nothing in particular.
+//
+// topoSortCombOps() has always detected this (its wireAssignCount guard) but
+// signals it with the same `false` it uses for a genuine combinational cycle,
+// and emitFunc's response to that `false` is to fall back to a name-order sort
+// and emit every assign regardless. So the condition was recognised by name,
+// discarded, and the broken netlist written out silently. Downstream tools do
+// not save you: yosys warns but proceeds, and verilator 5.044 accepts such a
+// netlist with no diagnostic at all, even under -Wall.
+//
+// Refuse instead, and name the nets. Order is deterministic (MapVector) so the
+// diagnostic is diffable.
+static LogicalResult checkSingleDriver(func::FuncOp f, ArrayRef<Operation *> ops, NameTable &nt,
+                                       bool allowMultiDriven) {
+  llvm::MapVector<Value, unsigned> assignCount;
+  for (Operation *op : ops)
+    if (auto a = dyn_cast<pyc::AssignOp>(op))
+      assignCount[a.getDst()]++;
+
+  llvm::SmallVector<std::pair<std::string, unsigned>> offenders;
+  unsigned extraDrivers = 0;
+  for (auto &kv : assignCount)
+    if (kv.second > 1) {
+      offenders.emplace_back(nt.get(kv.first), kv.second);
+      extraDrivers += kv.second - 1;
+    }
+
+  if (offenders.empty())
+    return success();
+
+  const unsigned kMaxListed = 10;
+  std::string detail;
+  {
+    llvm::raw_string_ostream d(detail);
+    d << offenders.size() << " net(s) in module '" << f.getSymName() << "' have more than one continuous driver ("
+      << extraDrivers << " redundant assign(s)):";
+    for (auto [i, o] : llvm::enumerate(offenders)) {
+      if (i >= kMaxListed) {
+        d << "\n    ... and " << (offenders.size() - kMaxListed) << " more";
+        break;
+      }
+      d << "\n    " << o.first << " <- " << o.second << " drivers";
+    }
+  }
+
+  if (allowMultiDriven) {
+    // Deliberately llvm::errs() and not f.emitWarning(): pycc registers no
+    // MLIR diagnostic handler, and DiagnosticEngine's fallback prints errors
+    // only — a warning would be dropped on the floor. Silently emitting a
+    // netlist known to be undefined is the exact failure this check exists to
+    // end, so the escape hatch has to be audible.
+    llvm::errs() << "warning: " << detail
+                 << "\n  emitting anyway (--allow-multidriven): the result is undefined Verilog"
+                    " and does not implement the design\n";
+    return success();
+  }
+
+  f.emitError() << detail
+                << "\n  a continuous `assign` is a driver, not a statement, so this is undefined Verilog."
+                   "\n  The usual cause is a register written through several guarded writes: each write must"
+                   "\n  chain onto the running next-state value, leaving ONE assign per net, rather than emit"
+                   "\n  its own assign defaulting to the register's current value."
+                   "\n  Pass --allow-multidriven to emit it anyway (reproduces the historical, broken output).";
+  return failure();
+}
+
 static bool topoSortCombOps(ArrayRef<Operation *> ops, NameTable &nt, llvm::SmallVectorImpl<Operation *> &ordered) {
   ordered.clear();
   if (ops.empty())
@@ -1065,6 +1137,15 @@ static LogicalResult emitFunc(func::FuncOp f, raw_ostream &os, const VerilogEmit
   auto cmp = [&](Operation *a, Operation *b) { return opSortKey(a, nt) < opSortKey(b, nt); };
   std::sort(instOps.begin(), instOps.end(), cmp);
   std::sort(seqInstOps.begin(), seqInstOps.end(), cmp);
+
+  // Before sorting: refuse multi-driver nets. This has to happen here rather
+  // than inside topoSortCombOps, because by the time that function's `false`
+  // reaches the fallback below, the name-order sort has already destroyed the
+  // program order that says which assign was meant to win — so there is no
+  // longer enough information to report, let alone repair, the conflict.
+  if (failed(checkSingleDriver(f, combAssignOps, nt, opts.allowMultiDriven)))
+    return failure();
+
   llvm::SmallVector<Operation *> orderedComb;
   if (!topoSortCombOps(combAssignOps, nt, orderedComb))
     std::sort(combAssignOps.begin(), combAssignOps.end(), cmp);

--- a/compiler/mlir/tools/pycc.cpp
+++ b/compiler/mlir/tools/pycc.cpp
@@ -158,6 +158,12 @@ static llvm::cl::opt<bool> includePrims("include-primitives",
                                         llvm::cl::desc("Emit `include` for PYC Verilog primitives"),
                                         llvm::cl::init(true));
 
+static llvm::cl::opt<bool>
+    allowMultiDriven("allow-multidriven",
+                     llvm::cl::desc("Emit Verilog nets that have more than one continuous driver instead of "
+                                    "failing (undefined Verilog; reproduces the historical broken output)"),
+                     llvm::cl::init(false));
+
 static llvm::cl::opt<std::string>
     outDir("out-dir", llvm::cl::desc("Output directory (split per module; emits manifest.json)"), llvm::cl::init(""));
 
@@ -2464,6 +2470,7 @@ int main(int argc, char **argv) {
       pyc::VerilogEmitterOptions opts;
       opts.includePrimitives = false; // out-dir mode uses pyc_primitives.v (or expects external primitives)
       opts.targetFpga = targetFpga;
+      opts.allowMultiDriven = allowMultiDriven;
 
       for (auto f : module->getOps<func::FuncOp>()) {
         if (f.isDeclaration())
@@ -2854,6 +2861,7 @@ int main(int argc, char **argv) {
     }
     pyc::VerilogEmitterOptions opts;
     opts.includePrimitives = includePrims;
+    opts.allowMultiDriven = allowMultiDriven;
     if (targetKind == "fpga")
       opts.targetFpga = true;
     else if (targetKind != "default") {


### PR DESCRIPTION
## Summary

Two commits, one root cause: a register written through several guarded writes emitted
**one `pyc.assign` per write**, so it ended up with N continuous drivers in Verilog and only
its last guard live.

| Commit | Layer | What it does |
|---|---|---|
| `fix(frontend): chain guarded register writes into one driver` | `compiler/frontend/pycircuit/hw.py` | `Reg.set(v, when=c)` now chains into a single priority mux, leaving exactly one `pyc.assign` per register |
| `fix(verilog): refuse to emit multi-driver nets instead of name-sorting them` | `compiler/mlir/{lib/Emit/VerilogEmitter.cpp, include/pyc/Emit/VerilogEmitter.h, tools/pycc.cpp}` | The emitter now fails on a net with >1 `pyc.assign` and names the offenders, instead of silently emitting undefined Verilog |

The frontend commit fixes the bug; the emitter commit makes the class of bug impossible to ship
silently again. They are independent and can be reviewed separately.

## Motivation

### The defect

`Reg.set(v, when=c)` emitted, per call, an independent

```
pyc.assign next, mux(c, v, q)
```

Every mux fell back to the register's **current** value `q`, not to the running next-state value.
Two distinct defects follow from that one line:

* **Semantic.** The DSL contract is that later writes override earlier ones and an unguarded
  register holds. Because every mux defaulted to `q`, the *last* assign decided the outcome
  unconditionally: for writes `(c0,v0)…(cN,vN)` the result was `cN ? vN : q`, and guards
  `c0…cN-1` were dead. **This is wrong in the C++ backend too, not only in Verilog.**
* **Structural.** N assigns to one wire is N continuous drivers in Verilog, which is undefined;
  yosys and verilator resolve it arbitrarily and differently.

### Nothing caught it

`topoSortCombOps()` *already detected* the condition — the comment at its `wireAssignCount` guard
reads "Verilog does not support multiple continuous drivers for a single net in this prototype" —
but signalled it with the same `false` it returns for a genuine combinational cycle. `emitFunc`'s
response to that `false` is to fall back to a name-order `std::sort` and emit every assign anyway.
So the condition was recognised **by name**, discarded, and the undefined netlist written out with
no diagnostic.

Downstream tools do not save you either: yosys warns but proceeds, and **verilator 5.044 accepts
such a netlist with exit 0 and no diagnostic at all, even under `-Wall`**.

### Measured impact

On an out-of-tree design (DavinciOO's `davinci_top`, via our review branch), the pre-fix frontend
produced **322 multiply-driven nets** and **1476 redundant drivers** — `scalar_free_list` 96,
`tile_free_list` 224, `muldiv` 2 — and yosys' first CHECK pass reported 2470 problems.
A full-interface replay of that design's own traces showed the Verilog and C++ backends of
the *same* `.mlir` disagreeing on **12 of 130 top-level outputs across 3099 of 20000 cycles** —
specifically the rename/completion tags, i.e. physical register allocation.

The free-list pattern that triggers it is ordinary: one guarded write per enqueue port. With the
old lowering, only the last port's enqueue could ever take effect.

After the fix: 0 multiply-driven nets, both yosys CHECK passes clean. ASAP7 area rises
9430.72 → 12184.97 um² **because the broken netlist let synthesis prune five of every six mux
cones and delete the flip-flops behind them** — 9957 of 17504 declared state bits retained before,
12513 after. The area increase is the bug being repaired, not a regression.

### Why it survived in-tree

**All 24 emittable `designs/examples/*` emit byte-identical MLIR before and after the frontend
change** — not one of them writes a single register through multiple guarded writes. (`designs/
examples/` holds 28 directories; 24 carry a `tb_*.py` and are the ones the example gate emits.)
The in-tree corpus simply does not cover the pattern. See *Follow-ups* below.

## What changed

### Frontend (`hw.py`)

Chain the muxes into one priority expression (later guard wins, `q` as the base case) and keep
exactly **one** `pyc.assign` per register. Two details worth a reviewer's attention:

* The replacement assign is **appended, not written back over the old line.** The new mux's SSA
  definition comes *after* the previous assign's position, so patching the old slot in place would
  emit a use before its def and violate MLIR dominance. The superseded line is blanked instead —
  blanking rather than deleting keeps every other register's recorded line index valid.
* State lives on the `Module` (keyed by the next-wire ref) because `Reg` is a frozen dataclass. It
  is per-Module and therefore per-elaboration, which is the correct lifetime.

Emitters are untouched by this commit, so it needs no `pycc` rebuild.

### Emitter (`VerilogEmitter.cpp`, `pycc.cpp`)

`checkSingleDriver()` runs **before the sort** — after the name-order fallback runs, the program
order that says which assign was meant to win is already gone, so there is no longer enough
information to report, let alone repair, the conflict. It fails with the offending net names, the
driver count, and the usual root cause:

```
error: 1 net(s) in module 'f13_multidrive' have more than one continuous driver (2 redundant assign(s)):
    acc__next <- 3 drivers
  a continuous `assign` is a driver, not a statement, so this is undefined Verilog.
  The usual cause is a register written through several guarded writes: each write must
  chain onto the running next-state value, leaving ONE assign per net, rather than emit
  its own assign defaulting to the register's current value.
  Pass --allow-multidriven to emit it anyway (reproduces the historical, broken output).
```

Order is deterministic (`llvm::MapVector`) so the diagnostic is diffable. New flag
`pycc --allow-multidriven` restores the old behaviour for reproducing historical output and says
so on stderr — deliberately via `llvm::errs()` and not `emitWarning()`, because `pycc` registers no
MLIR diagnostic handler and `DiagnosticEngine`'s fallback prints errors only, so a warning would be
dropped on the floor. Silently emitting a netlist known to be undefined is the exact failure this
check exists to end, so the escape hatch has to be audible.

## Decision IDs

**Decision 0130** (*Net/var split is enforced: single-driver vars; resolved nets*) already requires
this, and predicted this exact failure mode:

> **var/state**: exactly one driver; no resolution; may not take Z.
> Add an MLIR verifier: reject var/state values with 0 or >1 drivers.
> *Without an explicit, verified split, C++ and Verilog will diverge (e.g. last-writer-wins vs
> Verilog resolution).*

That divergence is precisely what was measured above. `docs/gates/decision_status_v40.md` lists
0130 as `implemented-verified`, but the mandated enforcement was not present on any path — `pycc`
emitted a 3-driver `acc__next` at exit 0. This PR supplies it **partially**; see *Scope* for what
it does not cover.

Context also: **Decision 0137** (frontend must not use `wire`/`assign` hacks to express
multi-driver intent) — the old `Reg.set` lowering was exactly such an implicit hack.

## Scope — what this PR does *not* fix

Verified against the built compiler, so the gap is precise rather than assumed:

| Case | Status after this PR |
|---|---|
| >1 driver on the **Verilog** emission path | **rejected** (this PR) |
| >1 driver on the **C++** emission path | still accepted silently — `pycc --emit=cpp` on a 3-driver netlist exits 0 with no driver diagnostic |
| **0 drivers** on a var/state | still accepted silently — exits 0 |
| A real **dialect verifier** per Decision 0130 | not added; the check lives in the Verilog emitter |

The frontend fix means pyCircuit no longer *generates* any of these, so the C++ and 0-driver holes
are only reachable via hand-written or third-party MLIR. Closing them properly is a dialect-verifier
change, which felt out of scope for a bug fix — happy to do it in a follow-up if you'd prefer it
here.

## Reproducing it without our design

Every number in *Measured impact* comes from an out-of-tree design, which is not a basis on
which to ask you to take a compiler change. The pattern reproduces in **109 lines against
pyCircuit alone**, with no dependency on that design or any other:

```python
# one register, N guarded writes, keep-current default -- the free-list pattern
for i in range(n_ports):
    acc.set(value[i], when=hit & valid[i])
```

Emit it and look for: one `pyc.wire` named `acc__next`, one `pyc.reg` whose `d` is that wire, and
then **N independent** `pyc.assign %acc__next, mux(c_i, v_i, %cur)` ops — every mux defaulting to
the register's *current* value instead of chaining onto the previous assign's result. That
non-chaining is the whole defect. Three ports is enough; two triggers it.

We have this as a standalone script and can add it to this PR as a
`designs/examples/multi_guarded_write_smoke/` case with a `run_case` line in
`flows/scripts/run_semantic_regressions_v40.sh`, next to the existing `net_resolution_depth_smoke`
— see *Follow-ups* item 1. Given that the absence of exactly this coverage is why the bug
shipped, we would suggest taking it in this PR rather than after it; say which you prefer.

## Testing

All gates run locally against this branch, on LLVM/MLIR 19:

| Gate | Command | Result |
|---|---|---|
| G0 Python checks | `python3 -m py_compile <packaging+cli set>`; `python3 flows/tools/check_api_hygiene.py compiler/frontend/pycircuit designs/examples docs README.md` | **pass** — "ok: API hygiene check passed" |
| G0 build toolchain | `bash flows/scripts/pyc build` | **pass** — exit 0, no new warnings (all 10 build warnings are pre-existing, in `Transforms/` and `Dialect/`; none from the two changed .cpp) |
| G0 wheel smoke | installed-wheel smoke | not run locally — CI covers it; the frontend change is pure Python with no packaging surface |
| G1 examples + semantic gates | `bash flows/scripts/run_examples.sh` | **pass** — "all examples passed" (semantic regressions on, `PYC_SKIP_SEMANTIC_REGRESSIONS` unset) |
| G2 cross-backend sims | `bash flows/scripts/run_sims.sh` | **pass** — "all sims passed" |

### Targeted checks

A 3-guarded-write register (`acc.set(d0,when=c0); acc.set(d1,when=c1); acc.set(d2,when=c2)`) run
through `python3 -m pycircuit.cli emit`:

* **one** `pyc.assign %v1` (`acc__next`), fed by a 3-deep priority chain `%v15 ← %v14 ← %v13 ← %v6`,
  terminating at `q` — not three assigns each defaulting to `q`.
* `pycc --emit=verilog` on it: **exit 0**.
* Same file with the assign hand-duplicated to 3 (the pre-fix shape): **exit 1**, diagnostic above.
* Same file with `--allow-multidriven`: exit 0, warning on stderr, netlist emitted.

### "Purely additive" — verified, not asserted

I built a second `pycc` from **unmodified `main`** and diffed its output against this branch's,
same input MLIR both times:

* Clean netlist: **byte-identical** (2393 B).
* All 24 `designs/examples/*`: **24/24 byte-identical** Verilog.
* Dirty netlist with `--allow-multidriven`: **byte-identical** to baseline (2599 B).
* Baseline `pycc` on the dirty netlist: exit 0, **zero mentions of drivers** on stderr — confirming
  the silent-failure premise on current `main`, not only on the branch where it was found.

Emitted MLIR is likewise byte-identical for all 24 examples before/after the frontend change, so
**no examples need regenerating.**

### Note on `pytest`

`pytest tests designs` reports 55 failures on this branch — **all pre-existing.** A clean worktree
of `main` and a clean worktree of this branch both give exactly `55 failed, 203 passed, 76 skipped`
(XiangShan-pyc `build_*` discovery). `pytest` is not part of CI. Beware that leftover
`.pycircuit_out/` and `__pycache__/` artifacts from a gate run convert the 76 skips into failures —
compare clean checkouts.

## Follow-ups (not in this PR)

1. **A regression case for the pattern.** Nothing in-tree exercises multiple guarded writes to one
   register, which is why this shipped. The natural home is a
   `designs/examples/multi_guarded_write_smoke/tb_multi_guarded_write_smoke.py` plus a `run_case`
   line in `flows/scripts/run_semantic_regressions_v40.sh`, next to the existing
   `net_resolution_depth_smoke`. Say the word and I'll add it here.
2. **The dialect verifier** Decision 0130 actually asks for, covering the C++ path and the 0-driver
   case (see *Scope*).

## Checklist

- [x] G0/G1/G2 gates pass locally (see Testing; CI will re-run them)
- [x] Code is formatted — **tool-verified.** `black --line-length 88` does not touch a single one
      of the 62 lines this PR adds. `ruff check` with your `pyproject.toml` selectors reports 5 new
      findings, all `UP037` (quoted type annotations) — a rule `hw.py` already trips **183** times
      on `main`, so our 5 match the file's prevailing style; "fix" them alone and the new code stops
      matching its surroundings. Happy to convert them if you would rather, but it seemed wrong to
      change style in 5 places out of 188 in a bug-fix PR.
- [x] Documentation: no change needed — no doc enumerates `pycc` flags, and `docs/rfcs/pyc4.0-decisions.md`
      already specifies the enforced behaviour (0130)
- [x] Examples regenerated: not applicable — output proven byte-identical for all 24
- [x] No new warnings
- [x] Decision IDs referenced (0130, context 0137)

## Reproduce

```sh
# toolchain (LLVM/MLIR 19) -- the canonical wrapper
bash flows/scripts/pyc build
export PYC_TOOLCHAIN_ROOT=$PWD/install PATH=$PWD/install/bin:$PATH

# gates
python3 flows/tools/check_api_hygiene.py compiler/frontend/pycircuit designs/examples docs README.md
bash flows/scripts/run_examples.sh     # G1
bash flows/scripts/run_sims.sh         # G2

# the fix, end to end: 3 guarded writes -> 1 assign; duplicate it -> refused
python3 -m pycircuit.cli emit <design-with-3-guarded-writes>.py -o d.pyc
grep -c 'pyc.assign %v1' d.pyc                      # 1
pycc --emit=verilog d.pyc -o d.v                    # exit 0
# duplicate the assign line twice, then:
pycc --emit=verilog d_bad.pyc -o bad.v              # exit 1, names acc__next
pycc --emit=verilog --allow-multidriven d_bad.pyc -o bad.v   # exit 0 + warning
```

Environment for the numbers above: Linux x86-64, Python 3.11, LLVM/MLIR 19.1, GCC 13.3.0,
verilator 5.044 (above your 5.024 floor; CI pins 5.048), iverilog 11.0.
